### PR TITLE
Improve Test Plan Specs

### DIFF
--- a/manifests/chew-datasets.toml
+++ b/manifests/chew-datasets.toml
@@ -1,37 +1,52 @@
 name = "chew-datasets"
 
-# hashicorp/go-getter URLs, so in the future we can support fetching test plans from GitHub.
+# hashicorp/go-getter URLs support.
 source_path = "file:${TESTGROUND_SRCDIR}/plans/chew-datasets"
 
 [defaults]
 builder = "docker:go"
 runner = "local:docker"
 
-[build_strategies."docker:go"]
-enabled = true
-go_version = "1.13"
-module_path = "github.com/ipfs/testground/plans/chew-datasets"
-exec_pkg = "."
-go_ipfs_version = "0.4.22"
+# Builder strategies
 
-# TODO
-[build_strategies."exec:go"]
+[[builders]]
+name="docker:go"
 enabled = true
 module_path = "github.com/ipfs/testground/plans/chew-datasets"
 exec_pkg = "."
+    [builders.params]
+    go_version = { type = "string", desc = "the go lang version to be used", default: "1.13" }
+    go_ipfs_version = { type = "string", desc = "the go-ipfs version to be tested", default: "0.4.22" }
 
-[run_strategies."local:docker"]
+[[builders]]
+name="exec:go"
 enabled = true
+module_path = "github.com/ipfs/testground/plans/chew-datasets"
+exec_pkg = "."
+    [builders.params]
 
-# TODO
-[run_strategies."local:exec"]
+# Runner strategies
+
+[[runners]]
+name = "local:exec"
 enabled = true
+    [runners.params]
+    cpu = { type = "string", desc = "the amount of CPU to be accessible to the runner" }
+    ram = { type = "string", desc = "the amount of RAM to be accessible to the runner" }
 
-# TODO
-[run_strategies."cluster:nomad"]
+[[runners]]
+name = "local:docker"
 enabled = true
+    [runners.params]
 
-# seq 0
+[[runners]]
+name = "cluster:nomad"
+enabled = false
+    [runners.params]
+
+
+# Test cases
+
 [[testcases]]
 name = "ipfs-add-defaults"
 instances = { min = 1, max = 1, default = 1 }
@@ -39,7 +54,6 @@ instances = { min = 1, max = 1, default = 1 }
   [testcases.params]
   some_param = { type = "int", desc = "some param", unit = "peers" }
 
-# seq 1
 [[testcases]]
 name = "ipfs-add-trickle-dag"
 instances = { min = 1, max = 1, default = 1 }
@@ -47,7 +61,6 @@ instances = { min = 1, max = 1, default = 1 }
   [testcases.params]
   some_param = { type = "int", desc = "some param", unit = "peers" }
 
-# seq 2
 [[testcases]]
 name = "ipfs-add-dir-sharding"
 instances = { min = 1, max = 1, default = 1 }
@@ -55,7 +68,6 @@ instances = { min = 1, max = 1, default = 1 }
   [testcases.params]
   some_param = { type = "int", desc = "some param", unit = "peers" }
 
-# seq 3
 [[testcases]]
 name = "ipfs-mfs"
 instances = { min = 1, max = 1, default = 1 }
@@ -63,7 +75,6 @@ instances = { min = 1, max = 1, default = 1 }
   [testcases.params]
   some_param = { type = "int", desc = "some param", unit = "peers" }
 
-# seq 4
 [[testcases]]
 name = "ipfs-mfs-dir-sharding"
 instances = { min = 1, max = 1, default = 1 }
@@ -71,7 +82,6 @@ instances = { min = 1, max = 1, default = 1 }
   [testcases.params]
   some_param = { type = "int", desc = "some param", unit = "peers" }
 
-# seq 5
 [[testcases]]
 name = "ipfs-url-store"
 instances = { min = 1, max = 1, default = 1 }
@@ -79,7 +89,6 @@ instances = { min = 1, max = 1, default = 1 }
   [testcases.params]
   some_param = { type = "int", desc = "some param", unit = "peers" }
 
-# seq 6
 [[testcases]]
 name = "ipfs-file-store"
 instances = { min = 1, max = 1, default = 1 }

--- a/plans/chew-datasets/README.md
+++ b/plans/chew-datasets/README.md
@@ -4,7 +4,7 @@
 
 IPFS supports an ever-growing set of ways in how a File or Files can be added to the Network (Regular IPFS Add, MFS Add, Sharding, Balanced DAG, Trickle DAG, File Store, URL Store). This test plan checks their performance
 
-## What is being optimized (min/max, reach)
+## What is being optimized/measured (min/max, reach)
 
 - (Minimize) Memory used when performing each of the instructions
 - (Minimize) Time spent time chewing the files/directories
@@ -15,24 +15,18 @@ IPFS supports an ever-growing set of ways in how a File or Files can be added to
 
 ## Plan Parameters
 
-- **Network Parameters**
-  - `Region` - Region or Regions where the test should be run at (default to single region)
-  - `N` - Number of nodes that are spawn for the test (from 10 to 1000000)
-- **Image Parameters**
-  - Single Image - The go-ipfs commit that is being tested
-  - Image Resources CPU & Ram
-  - Offline/Online - Specify if you want the node to run connected to the other nodes or not
+- **Builder Parameters**: Found on the [manifest](../manifests/chew-datasets.toml)
+- **Runner Parameters**: Found on the [manifest](../manifests/chew-datasets.toml)
+- **Network Parameters**: Found on the [manifest](../manifests/chew-datasets.toml)
 
 ## Tests
 
 ### `Test:` IPFS Add Defaults
 
-- **Test parameters**
-  - `File Sizes` - An array of File Sizes to be tested (default to: `[1MB, 10MB, 100MB, 1GB, 10GB]`)
-  - `Mode` - A string indicating if the test must be run against the `coreapi` or `daemon` (default is both).
+- **Test parameters**: Found on the [manifest](../manifests/chew-datasets.toml)
 - **Narrative**
   - **Warm up**
-    - The IPFS node/daemon is created 
+    - The IPFS node/daemon is created
     - If Online, connect to the other nodes running
     - Generate the Random Data that follows what was specificied by the params `File Sizes` and `Directory Depth`
   - **Act I**
@@ -40,12 +34,10 @@ IPFS supports an ever-growing set of ways in how a File or Files can be added to
 
 ### `Test:` IPFS Add Trickle DAG
 
-- **Test parameters**
-  - `File Sizes` - An array of File Sizes to be tested (default to: `[1MB, 10MB, 100MB, 1GB, 10GB]`)
-  - `Mode` - A string indicating if the test must be run against the `coreapi` or `daemon` (default is both).
+- **Test parameters**: Found on the [manifest](../manifests/chew-datasets.toml)
 - **Narrative**
   - **Warm up**
-    - The IPFS node/daemon is created 
+    - The IPFS node/daemon is created
     - If Online, connect to the other nodes running
     - Generate the Random Data that follows what was specificied by the params `File Sizes` and `Directory Depth`
   - **Act I**
@@ -53,9 +45,7 @@ IPFS supports an ever-growing set of ways in how a File or Files can be added to
 
 ### `Test:`  IPFS Add Dir Sharding
 
-- **Test parameters**
-  - `Directory Depth` - An Array containing objects that describe how deep/nested a directory goes and the size of files that can be found throughout (default to `[{depth: 10, size: 1MB}, {depth: 50, size: 1MB}]`
-  - `Mode` - A string indicating if the test must be run against the `coreapi` or `daemon` (default is both).
+- **Test parameters**: Found on the [manifest](../manifests/chew-datasets.toml)
 - **Narrative**
   - **Warm up**
     - The IPFS node/daemon is created with _sharding experiment enabled_
@@ -66,12 +56,10 @@ IPFS supports an ever-growing set of ways in how a File or Files can be added to
 
 ### `Test:` IPFS MFS Write
 
-- **Test parameters**
-  - `File Sizes` - An array of File Sizes to be tested (default to: `[1MB, 1GB, 10GB]`)
-  - `Mode` - A string indicating if the test must be run against the `coreapi` or `daemon` (default is both).
+- **Test parameters**: Found on the [manifest](../manifests/chew-datasets.toml)
 - **Narrative**
   - **Warm up**
-    - The IPFS node/daemon is created 
+    - The IPFS node/daemon is created
     - If Online, connect to the other nodes running
     - Generate the Random Data that follows what was specificied by the params `File Sizes` and `Directory Depth`
   - **Act I**
@@ -83,9 +71,7 @@ IPFS supports an ever-growing set of ways in how a File or Files can be added to
 
 ### `Test:` IPFS MFS Dir Sharding
 
-- **Test parameters**
-  - `Directory Depth` - An Array containing objects that describe how deep/nested a directory goes and the size of files that can be found throughout (default to `[{depth: 10, size: 1MB}, {depth: 50, size: 1MB}]`
-  - `Mode` - A string indicating if the test must be run against the `coreapi` or `daemon` (default is both).
+- **Test parameters**: Found on the [manifest](../manifests/chew-datasets.toml)
 - **Narrative**
   - **Warm up**
     - The IPFS node/daemon is created with _sharding experiment enabled_
@@ -101,10 +87,8 @@ IPFS supports an ever-growing set of ways in how a File or Files can be added to
 
 ### `Test:` IPFS Url Store
 
-- **Test parameters**
-  - `File Sizes` - An array of File Sizes to be tested (default to: `[1MB, 1GB, 10GB]`)
-  - `Directory Depth` - An Array containing objects that describe how deep/nested a directory goes and the size of files that can be found throughout (default to `[{depth: 10, size: 1MB}, {depth: 50, size: 1MB}]`
-  - `Mode` - A string indicating if the test must be run against the `coreapi` or `daemon` (default is both).
+
+- **Test parameters**: Found on the [manifest](../manifests/chew-datasets.toml)
 - **Narrative**
   - **Warm up**
     - The IPFS node/daemon is created _with url store experiment enabled_
@@ -121,10 +105,7 @@ IPFS supports an ever-growing set of ways in how a File or Files can be added to
 
 ### `Test:` IPFS File Store
 
-- **Test parameters**
-  - `File Sizes` - An array of File Sizes to be tested (default to: `[1MB, 1GB, 10GB]`)
-  - `Directory Depth` - An Array containing objects that describe how deep/nested a directory goes and the size of files that can be found throughout (default to `[{depth: 10, size: 1MB}, {depth: 50, size: 1MB}]`
-  - `Mode` - A string indicating if the test must be run against the `coreapi` or `daemon` (default is both).
+- **Test parameters**: Found on the [manifest](../manifests/chew-datasets.toml)
 - **Narrative**
   - **Warm up**
     - The IPFS node/daemon is created _with file store experiment enabled_


### PR DESCRIPTION
I've been wanting to scratch a itch for a while... 

Currently, the plan specs are detached from the manifests, one has to manually update both. This is cumbersome and it basically throws us in the traditional problem of any spec document, that the implementation starts to differ from the spec.

At the same time, our manifest didn't offer an uniform way to describe the different properties and parameters for Builders, Runners and Tests. 

This PR is a proposal to:
- Remove the description of the parameters in the plan specs and instead use the manifest file for that
- Create a uniform way to describe the different Builders, Runners and Tests
- (extra) remove those `seq` numbers for each test case. We really don't need them :) 

Given that this will require a bunch of refactor, I wanted to pass it through you before creating the complete PR. What do you think?


