### PR TITLE
Add a few more small tests  and ignores plans/ on Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
         - GO111MODULE=on pushd .. && go get github.com/golangci/golangci-lint/cmd/golangci-lint && popd
         - golangci-lint run       # run a bunch of code checkers/linters in parallel
         - go build ./...          # build the project
-        - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./... # Run all the tests with the race detector enabled
+        - go test -v -race -coverprofile=coverage.txt -covermode=atomic github.com/ipfs/testground... # Run all the tests with the race detector enabled
         - go build .
       after_success:
         - bash <(curl -s https://codecov.io/bash)
@@ -38,7 +38,6 @@ jobs:
         - echo 'travis_fold:start:go.mod.graph' && echo 'go mod graph' && go mod graph && echo 'travis_fold:end:go.mod.graph'
         - go build ./...          # build the project
         # Redis is missing on Windows so we skip the tests here
-        # - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...  # Run all the tests with the race detector enabled
         - go build .
       after_success:
         - bash <(curl -s https://codecov.io/bash)

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -41,3 +41,19 @@ func TestBuildDockerGo(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestDefaultBuildOptions(t *testing.T) {
+	app := cli.NewApp()
+	app.Name = "testground"
+	app.Commands = Commands
+
+	err := app.Run([]string{
+		"testground",
+		"build",
+		"placebo",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/describe_test.go
+++ b/cmd/describe_test.go
@@ -22,7 +22,7 @@ func TestDescribeExistingPlan(t *testing.T) {
 	}
 }
 
-func TestDescribeUnexistingPlan(t *testing.T) {
+func TestDescribeNonexistingPlan(t *testing.T) {
 	app := cli.NewApp()
 	app.Name = "testground"
 	app.Commands = Commands

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -85,3 +85,19 @@ func TestCompatibleRun(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestDefaultRunOptions(t *testing.T) {
+	app := cli.NewApp()
+	app.Name = "testground"
+	app.Commands = Commands
+
+	err := app.Run([]string{
+		"testground",
+		"run",
+		"placebo/ok",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "plans"

--- a/pkg/tgwriter/tgwriter_test.go
+++ b/pkg/tgwriter/tgwriter_test.go
@@ -1,0 +1,131 @@
+package tgwriter
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestProgress(t *testing.T) {
+	w := httptest.NewRecorder()
+	log := zap.NewNop().Sugar()
+	tgw := New(w, log)
+
+	_, err := tgw.Write([]byte("testground"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure we wrote the message
+	tgw.Flush()
+
+	buf := new(bytes.Buffer)
+	res := w.Result()
+	_, err = buf.ReadFrom(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := &Msg{}
+	err = json.Unmarshal(buf.Bytes(), msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if msg.Type != "progress" {
+		t.Fatal(errors.New("message type must be 'progress'"))
+	}
+
+	txt, ok := msg.Payload.(string)
+	if !ok {
+		t.Fatal(errors.New("message not ok"))
+	}
+
+	m, err := base64.StdEncoding.DecodeString(txt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(m) != "testground" {
+		t.Fatal(errors.New("message not ok"))
+	}
+}
+
+func TestResult(t *testing.T) {
+	w := httptest.NewRecorder()
+	log := zap.NewNop().Sugar()
+	tgw := New(w, log)
+
+	tgw.WriteResult([]byte("testground"))
+
+	// make sure we wrote the message
+	tgw.Flush()
+
+	buf := new(bytes.Buffer)
+	res := w.Result()
+	_, err := buf.ReadFrom(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := &Msg{}
+	err = json.Unmarshal(buf.Bytes(), msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if msg.Type != "result" {
+		t.Fatal(errors.New("message type must be 'result'"))
+	}
+
+	txt, ok := msg.Payload.(string)
+	if !ok {
+		t.Fatal(errors.New("message not ok"))
+	}
+
+	m, err := base64.StdEncoding.DecodeString(txt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(m) != "testground" {
+		t.Fatal(errors.New("message not ok"))
+	}
+}
+
+func TestError(t *testing.T) {
+	w := httptest.NewRecorder()
+	log := zap.NewNop().Sugar()
+	tgw := New(w, log)
+
+	tgw.WriteError("testground")
+
+	// make sure we wrote the message
+	tgw.Flush()
+
+	buf := new(bytes.Buffer)
+	res := w.Result()
+	_, err := buf.ReadFrom(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := &Msg{}
+	err = json.Unmarshal(buf.Bytes(), msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if msg.Type != "error" {
+		t.Fatal(errors.New("message type must be 'error'"))
+	}
+
+	if msg.Error.Message != "testground" {
+		t.Fatal(errors.New("message not ok"))
+	}
+}

--- a/sdk/iptb/spec_test.go
+++ b/sdk/iptb/spec_test.go
@@ -1,0 +1,42 @@
+package iptb
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewTestEnsembleSpec(t *testing.T) {
+	spec := NewTestEnsembleSpec()
+	if !reflect.DeepEqual(spec, &TestEnsembleSpec{
+		tags: make(map[string]NodeOpts),
+	}) {
+		t.Fail()
+	}
+}
+
+func TestEnsembleSpecConfig(t *testing.T) {
+	spec := NewTestEnsembleSpec()
+	spec.AddNodesDefaultConfig(NodeOpts{}, "t1")
+
+	if !reflect.DeepEqual(spec, &TestEnsembleSpec{
+		tags: map[string]NodeOpts{
+			"t1": NodeOpts{},
+		},
+	}) {
+		t.Fail()
+	}
+}
+
+func TestEnsembleSpecPanicSameTag(t *testing.T) {
+	spec := NewTestEnsembleSpec()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("function must have panicked")
+		}
+	}()
+
+	spec.AddNodesDefaultConfig(NodeOpts{}, "t1")
+	spec.AddNodesDefaultConfig(NodeOpts{}, "t1")
+}


### PR DESCRIPTION
- Adds a few more small tests.
- Ignores `plans/` on Codecov since they are actual... tests. This will make a bump in the coverage amount because it was counting with those files (I guess... waiting for CI).

**Update**: since go modules, `go test ./...` only tests the current module and not **everything in the directory** so we've not been running all of our tests... https://github.com/golang/go/wiki/Modules#should-i-have-multiple-modules-in-a-single-repository