### PR TITLE
Plan: secure-channel

### DIFF
--- a/manifests/secure-channel.toml
+++ b/manifests/secure-channel.toml
@@ -1,0 +1,38 @@
+name = "secure-channel"
+# hashicorp/go-getter URLs, so in the future we can support fetching test plans
+# from GitHub.
+source_path = "file://${TESTGROUND_SRCDIR}/plans/secure-channel"
+
+[defaults]
+builder = "exec:go"
+runner = "local:exec"
+
+[build_strategies."docker:go"]
+enabled = false
+go_version = "1.13"
+module_path = "github.com/ipfs/testground/plans/secure-channel"
+exec_pkg = "."
+go_ipfs_version = "0.4.22"
+
+[build_strategies."exec:go"]
+enabled = true
+module_path = "github.com/ipfs/testground/plans/secure-channel"
+exec_pkg = "."
+
+[run_strategies."local:docker"]
+enabled = false
+
+[run_strategies."local:exec"]
+enabled = true
+
+[run_strategies."cluster:swarm"]
+enabled = false
+
+# seq 0
+[[testcases]]
+name = "transfer"
+instances = { min = 2, max = 200, default = 2 }
+
+  [testcases.params]
+  secure_channel = { type = "string", desc = "the secure channel protocol to use. values are: secio, noise, tls" }
+  payload_size = { type = "int", desc = "size of payload to transfer between peers", unit = "bytes" }

--- a/manifests/secure-channel.toml
+++ b/manifests/secure-channel.toml
@@ -36,3 +36,4 @@ instances = { min = 2, max = 200, default = 2 }
   [testcases.params]
   secure_channel = { type = "string", desc = "the secure channel protocol to use. values are: secio, noise, tls" }
   payload_size = { type = "int", desc = "size of payload to transfer between peers", unit = "bytes" }
+  timeout_secs = { type = "int", desc = "timeout", unit = "seconds", default = 60 }

--- a/manifests/secure-channel.toml
+++ b/manifests/secure-channel.toml
@@ -8,7 +8,7 @@ builder = "exec:go"
 runner = "local:exec"
 
 [build_strategies."docker:go"]
-enabled = false
+enabled = true
 go_version = "1.13"
 module_path = "github.com/ipfs/testground/plans/secure-channel"
 exec_pkg = "."
@@ -20,13 +20,13 @@ module_path = "github.com/ipfs/testground/plans/secure-channel"
 exec_pkg = "."
 
 [run_strategies."local:docker"]
-enabled = false
+enabled = true
 
 [run_strategies."local:exec"]
 enabled = true
 
 [run_strategies."cluster:swarm"]
-enabled = false
+enabled = true
 
 # seq 0
 [[testcases]]

--- a/plans/secure-channel/go.mod
+++ b/plans/secure-channel/go.mod
@@ -1,0 +1,30 @@
+module github.com/ipfs/testground/plans/secure-channel
+
+go 1.13
+
+replace github.com/ipfs/testground/sdk/runtime => ../../sdk/runtime
+
+replace github.com/ipfs/testground/sdk/sync => ../../sdk/sync
+
+require (
+	github.com/ipfs/testground/sdk/runtime v0.0.0-00010101000000-000000000000
+	github.com/ipfs/testground/sdk/sync v0.0.0-00010101000000-000000000000
+	github.com/libp2p/go-conn-security v0.1.0 // indirect
+	github.com/libp2p/go-libp2p v0.5.0
+	github.com/libp2p/go-libp2p-core v0.3.0
+	github.com/libp2p/go-libp2p-host v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-interface-connmgr v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-interface-pnet v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-metrics v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-net v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-noise v0.0.0-20200111143100-0f046f3f53a6
+	github.com/libp2p/go-libp2p-protocol v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-secio v0.2.1
+	github.com/libp2p/go-libp2p-tls v0.1.2
+	github.com/libp2p/go-libp2p-transport v0.1.0 // indirect
+	github.com/libp2p/go-stream-muxer v0.1.0 // indirect
+	github.com/whyrusleeping/go-smux-multiplex v3.0.16+incompatible // indirect
+	github.com/whyrusleeping/go-smux-multistream v2.0.2+incompatible // indirect
+	github.com/whyrusleeping/go-smux-yamux v2.0.9+incompatible // indirect
+	github.com/whyrusleeping/yamux v1.2.0 // indirect
+)

--- a/plans/secure-channel/go.mod
+++ b/plans/secure-channel/go.mod
@@ -7,24 +7,46 @@ replace github.com/ipfs/testground/sdk/runtime => ../../sdk/runtime
 replace github.com/ipfs/testground/sdk/sync => ../../sdk/sync
 
 require (
-	github.com/ipfs/testground/sdk/runtime v0.0.0-00010101000000-000000000000
-	github.com/ipfs/testground/sdk/sync v0.0.0-00010101000000-000000000000
+	github.com/ipfs/go-log v1.0.1 // indirect
+	github.com/ipfs/go-log/v2 v2.0.2 // indirect
+	github.com/ipfs/testground/sdk/runtime v0.0.0-20190921111954-a84ff142a5a3
+	github.com/ipfs/testground/sdk/sync v0.0.0-20190921111954-a84ff142a5a3
 	github.com/libp2p/go-conn-security v0.1.0 // indirect
-	github.com/libp2p/go-libp2p v0.5.0
+	github.com/libp2p/go-conn-security-multistream v0.1.0
+	github.com/libp2p/go-libp2p v0.5.1
+	github.com/libp2p/go-libp2p-blankhost v0.1.4
 	github.com/libp2p/go-libp2p-core v0.3.0
 	github.com/libp2p/go-libp2p-host v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-interface-connmgr v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-interface-pnet v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-metrics v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-mplex v0.2.1
 	github.com/libp2p/go-libp2p-net v0.1.0 // indirect
-	github.com/libp2p/go-libp2p-noise v0.0.0-20200111143100-0f046f3f53a6
+	github.com/libp2p/go-libp2p-noise v0.0.0-20200120141346-1a9c5941b6c7
+	github.com/libp2p/go-libp2p-peerstore v0.1.4
 	github.com/libp2p/go-libp2p-protocol v0.1.0 // indirect
 	github.com/libp2p/go-libp2p-secio v0.2.1
+	github.com/libp2p/go-libp2p-swarm v0.2.2
 	github.com/libp2p/go-libp2p-tls v0.1.2
 	github.com/libp2p/go-libp2p-transport v0.1.0 // indirect
+	github.com/libp2p/go-libp2p-transport-upgrader v0.1.1
 	github.com/libp2p/go-stream-muxer v0.1.0 // indirect
+	github.com/libp2p/go-stream-muxer-multistream v0.2.0
+	github.com/libp2p/go-tcp-transport v0.1.1
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/multiformats/go-multiaddr v0.2.0
+	github.com/multiformats/go-varint v0.0.2 // indirect
 	github.com/whyrusleeping/go-smux-multiplex v3.0.16+incompatible // indirect
 	github.com/whyrusleeping/go-smux-multistream v2.0.2+incompatible // indirect
 	github.com/whyrusleeping/go-smux-yamux v2.0.9+incompatible // indirect
 	github.com/whyrusleeping/yamux v1.2.0 // indirect
+	go.uber.org/atomic v1.5.1 // indirect
+	go.uber.org/multierr v1.4.0 // indirect
+	go.uber.org/zap v1.13.0 // indirect
+	golang.org/x/crypto v0.0.0-20200117160349-530e935923ad // indirect
+	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
+	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
+	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 // indirect
+	golang.org/x/tools v0.0.0-20200128002243-345141a36859 // indirect
 )

--- a/plans/secure-channel/main.go
+++ b/plans/secure-channel/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/ipfs/testground/plans/secure-channel/test"
+	"github.com/ipfs/testground/sdk/runtime"
+)
+
+var testCases = []func(*runtime.RunEnv){
+	test.TestDataTransfer,
+}
+
+func main() {
+	runenv := runtime.CurrentRunEnv()
+	if runenv.TestCaseSeq < 0 {
+		panic("test case sequence number not set")
+	}
+
+	// Demux to the right test case.
+	testCases[runenv.TestCaseSeq](runenv)
+}

--- a/plans/secure-channel/main.go
+++ b/plans/secure-channel/main.go
@@ -5,16 +5,19 @@ import (
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
-var testCases = []func(*runtime.RunEnv){
+var testCases = []func(*runtime.RunEnv) error {
 	test.TestDataTransfer,
 }
 
 func main() {
-	runenv := runtime.CurrentRunEnv()
+	runtime.Invoke(run)
+}
+
+func run(runenv *runtime.RunEnv) error {
 	if runenv.TestCaseSeq < 0 {
 		panic("test case sequence number not set")
 	}
 
 	// Demux to the right test case.
-	testCases[runenv.TestCaseSeq](runenv)
+	return testCases[runenv.TestCaseSeq](runenv)
 }

--- a/plans/secure-channel/test/node.go
+++ b/plans/secure-channel/test/node.go
@@ -1,0 +1,111 @@
+package test
+
+import (
+	"context"
+	csms "github.com/libp2p/go-conn-security-multistream"
+	blankhost "github.com/libp2p/go-libp2p-blankhost"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	host "github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/mux"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/sec"
+	"github.com/libp2p/go-libp2p-core/sec/insecure"
+	mplex "github.com/libp2p/go-libp2p-mplex"
+	noise "github.com/libp2p/go-libp2p-noise"
+	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
+	secio "github.com/libp2p/go-libp2p-secio"
+	swarm "github.com/libp2p/go-libp2p-swarm"
+	tls "github.com/libp2p/go-libp2p-tls"
+	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
+	msmux "github.com/libp2p/go-stream-muxer-multistream"
+	"github.com/libp2p/go-tcp-transport"
+	"github.com/multiformats/go-multiaddr"
+)
+
+func newHost(ctx context.Context, channelName string, key crypto.PrivKey) (host.Host, error) {
+	pid, err := peer.IDFromPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	ps := pstoremem.NewPeerstore()
+	err = ps.AddPrivKey(pid, key)
+	if err != nil {
+		return nil, err
+	}
+	err = ps.AddPubKey(pid, key.GetPublic())
+	if err != nil {
+		return nil, err
+	}
+
+	n := swarm.NewSwarm(ctx, pid, ps, nil) // TODO: add metrics reporter?
+
+	h := blankhost.NewBlankHost(n)
+
+	upgrader := new(tptu.Upgrader)
+	upgrader.Secure, err = makeSecurityTransport(channelName, key)
+	if err != nil {
+		h.Close()
+		return nil, err
+	}
+	upgrader.Muxer = makeMuxer()
+	tcpTpt := tcp.NewTCPTransport(upgrader)
+	err = n.AddTransport(tcpTpt)
+	if err != nil {
+		h.Close()
+		return nil, err
+	}
+
+	listenAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/0.0.0.0/tcp/0"),
+		multiaddr.StringCast("/ip6/::/tcp/0"),
+	}
+	if err := h.Network().Listen(listenAddrs...); err != nil {
+		h.Close()
+		return nil, err
+	}
+
+	return h, err
+}
+
+func makeSecurityTransport(name string, key crypto.PrivKey) (sec.SecureTransport, error) {
+	secMuxer := new(csms.SSMuxer)
+
+	switch name {
+	case "none":
+		id, err := peer.IDFromPrivateKey(key)
+		if err != nil {
+			return nil, err
+		}
+		tpt := insecure.NewWithIdentity(id, key)
+		secMuxer.AddTransport(insecure.ID, tpt)
+	case "secio":
+		tpt, err := secio.New(key)
+		if err != nil {
+			return nil, err
+		}
+		secMuxer.AddTransport(secio.ID, tpt)
+	case "tls":
+		tpt, err := tls.New(key)
+		if err != nil {
+			return nil, err
+		}
+		secMuxer.AddTransport(tls.ID, tpt)
+	case "noise":
+		tpt, err := noise.New(key)
+		if err != nil {
+			return nil, err
+		}
+		secMuxer.AddTransport(noise.ID, tpt)
+	default:
+		panic("unknown secure_channel option " + name)
+
+	}
+	return secMuxer, nil
+}
+
+func makeMuxer() mux.Multiplexer {
+	muxMuxer := msmux.NewBlankTransport()
+	muxMuxer.AddTransport("/mplex/6.7.0", mplex.DefaultTransport)
+	return muxMuxer
+}
+

--- a/plans/secure-channel/test/transfer.go
+++ b/plans/secure-channel/test/transfer.go
@@ -1,0 +1,236 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"github.com/ipfs/testground/sdk/runtime"
+	"github.com/ipfs/testground/sdk/sync"
+	libp2p "github.com/libp2p/go-libp2p"
+	core "github.com/libp2p/go-libp2p-core"
+	host "github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peerstore"
+	noise "github.com/libp2p/go-libp2p-noise"
+	secio "github.com/libp2p/go-libp2p-secio"
+	tls "github.com/libp2p/go-libp2p-tls"
+	"math/rand"
+	"time"
+)
+
+const protocolID = "/testground/secure-channel/transfer"
+
+func TestDataTransfer(runenv *runtime.RunEnv) {
+	n, err := makeNode(runenv)
+	if err != nil {
+		runenv.Abort(err)
+		return
+	}
+
+	if n.isInitiator {
+		// TODO: better peer selection
+		n.initiateTransfer(n.remotePeers[0].ID)
+	}
+
+	err = n.waitForAll("end")
+	if err != nil {
+		runenv.Abort(fmt.Errorf("error waiting for peers to signal test end: %s", err))
+		return
+	}
+
+	runenv.OK()
+}
+
+type node struct {
+	runenv      *runtime.RunEnv
+	syncWatcher *sync.Watcher
+	syncWriter  *sync.Writer
+
+	ctx  context.Context
+	host host.Host
+
+	remotePeers []peer.AddrInfo
+	isInitiator bool
+	payloadSize int
+
+	payloadSent     bool
+	payloadReceived bool
+}
+
+func makeNode(runenv *runtime.RunEnv) (*node, error) {
+	channelName := runenv.StringParam("secure_channel")
+	payloadSize := runenv.IntParam("payload_size")
+
+	// TODO: use context with configurable timeout
+	ctx := context.Background()
+
+	h, err := libp2p.New(ctx, securityOptForChannel(channelName))
+	if err != nil {
+		return nil, fmt.Errorf("error constructing libp2p host: %s", err)
+	}
+
+	runenv.Message("I am %s with addrs: %v", h.ID(), h.Addrs())
+
+	watcher, writer := sync.MustWatcherWriter(runenv)
+	seq, err := writer.Write(sync.PeerSubtree, host.InfoFromHost(h))
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get Redis Sync PeerSubtree %w", err)
+	}
+
+	isInitiator := seq%2 == 0
+
+	// get addrs for all peers
+	peerCh := make(chan *peer.AddrInfo)
+	cancelSub, err := watcher.Subscribe(sync.PeerSubtree, peerCh)
+	defer cancelSub()
+	addrInfos, err := addrInfosFromChan(peerCh, runenv.TestInstanceCount, 1*time.Minute)
+	if err != nil {
+		return nil, fmt.Errorf("error getting remote peer addrs: %s", err)
+	}
+
+	// add peers to peerstore so we can dial them later
+	for _, ai := range addrInfos {
+		h.Peerstore().AddAddrs(ai.ID, ai.Addrs, peerstore.RecentlyConnectedAddrTTL)
+	}
+
+	n := &node{
+		runenv:      runenv,
+		syncWatcher: watcher,
+		syncWriter:  writer,
+
+		ctx:         ctx,
+		host:        h,
+		remotePeers: addrInfos,
+		isInitiator: isInitiator,
+		payloadSize: payloadSize,
+	}
+	h.SetStreamHandler(protocolID, n.handleStream)
+	err = n.signalAndWaitForAll("ready")
+	if err != nil {
+		return nil, fmt.Errorf("error waiting for peers to signal ready state: %s", err)
+	}
+
+	return n, nil
+}
+
+func (n *node) handleStream(stream core.Stream) {
+	remotePeer := stream.Conn().RemotePeer()
+	n.runenv.Message(fmt.Sprintf("new stream from %s", remotePeer.Pretty()))
+
+	buf := make([]byte, n.payloadSize)
+	c, err := stream.Read(buf)
+	if err != nil {
+		n.runenv.Abort(fmt.Errorf("error reading from stream: %s", err))
+	}
+	if c != n.payloadSize {
+		n.runenv.Abort(fmt.Errorf("expected to read %d bytes, received %d", n.payloadSize, c))
+	}
+
+	n.runenv.Message(fmt.Sprintf("read %d bytes from %s", c, remotePeer.Pretty()))
+	n.payloadReceived = true
+	if n.payloadSent {
+		n.runenv.Message("payload sent and received. signalling test end")
+		n.signal("end")
+	} else {
+		n.runenv.Message("payload received, initiating transfer")
+		n.initiateTransfer(remotePeer)
+	}
+}
+
+func (n *node) initiateTransfer(p peer.ID) {
+	n.runenv.Message(fmt.Sprintf("initiating transfer to %s", p.Pretty()))
+
+	stream, err := n.host.NewStream(n.ctx, p, protocolID)
+	if err != nil {
+		n.runenv.Abort(fmt.Errorf("error opening stream to %s: %s", p.Pretty(), err))
+		return
+	}
+
+	c, err := stream.Write(makePayload(n.payloadSize))
+	if err != nil {
+		n.runenv.Abort(fmt.Errorf("error writing to stream: %s", err))
+	}
+	if c != n.payloadSize {
+		n.runenv.Abort(fmt.Errorf("expected to write %d bytes, wrote %d", n.payloadSize, c))
+	}
+
+	n.runenv.Message(fmt.Sprintf("wrote %d bytes to %s", c, p.Pretty()))
+	n.payloadSent = true
+	if n.payloadReceived {
+		n.runenv.Message("payload sent and received. signalling test end")
+		n.signal("end")
+	} else {
+		n.runenv.Message("payload sent, awaiting transfer from remote peer to complete test")
+	}
+}
+
+func makePayload(n int) []byte {
+	buf := make([]byte, n)
+	reader := rand.New(rand.NewSource(2))
+	_, err := reader.Read(buf)
+	if err != nil {
+		panic(fmt.Sprintf("error reading random data: %s", err))
+	}
+
+	return buf
+}
+
+func (n *node) signal(stateName string) error {
+	// Signal we've entered the state.
+	state := sync.State(stateName)
+	_, err := n.syncWriter.SignalEntry(state)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (n *node) waitForAll(stateName string) error {
+	// Set a state barrier.
+	state := sync.State(stateName)
+	instanceCount := n.runenv.TestInstanceCount
+	doneCh := n.syncWatcher.Barrier(n.ctx, state, int64(instanceCount))
+
+	// Wait until all others have signalled.
+	if err := <-doneCh; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (n *node) signalAndWaitForAll(stateName string) error {
+	// Signal we've entered the state.
+	err := n.signal(stateName)
+	if err != nil {
+		return err
+	}
+
+	return n.waitForAll(stateName)
+}
+
+func securityOptForChannel(channelName string) libp2p.Option {
+	switch channelName {
+	case "secio":
+		return libp2p.Security(secio.ID, secio.New)
+	case "tls":
+		return libp2p.Security(tls.ID, tls.New)
+	case "noise":
+		return libp2p.Security(noise.ID, noise.Maker())
+	}
+
+	panic("unknown secure_channel option " + channelName)
+}
+
+func addrInfosFromChan(peerCh chan *peer.AddrInfo, count int, timeout time.Duration) ([]peer.AddrInfo, error) {
+	var ais []peer.AddrInfo
+	for i := 1; i <= count; i++ {
+		select {
+		case ai := <-peerCh:
+			ais = append(ais, *ai)
+
+		case <-time.After(timeout):
+			return nil, fmt.Errorf("no new peers in %d seconds", timeout/time.Second)
+		}
+	}
+	return ais, nil
+}

--- a/plans/secure-channel/test/transfer.go
+++ b/plans/secure-channel/test/transfer.go
@@ -125,7 +125,7 @@ func makeNode(runenv *runtime.RunEnv) (*node, error) {
 
 func (n *node) handleStream(stream core.Stream) {
 	remotePeer := stream.Conn().RemotePeer()
-	n.runenv.Message(fmt.Sprintf("new stream from %s", remotePeer.Pretty()))
+	n.runenv.Message("new stream from %s", remotePeer.Pretty())
 
 	buf := make([]byte, n.payloadSize)
 	c, err := stream.Read(buf)
@@ -136,7 +136,7 @@ func (n *node) handleStream(stream core.Stream) {
 		n.runenv.Abort(fmt.Errorf("expected to read %d bytes, received %d", n.payloadSize, c))
 	}
 
-	n.runenv.Message(fmt.Sprintf("read %d bytes from %s", c, remotePeer.Pretty()))
+	n.runenv.Message("read %d bytes from %s", c, remotePeer.Pretty())
 	n.payloadReceived = true
 	if n.payloadSent {
 		n.runenv.Message("payload sent and received. signalling test end")
@@ -148,7 +148,7 @@ func (n *node) handleStream(stream core.Stream) {
 }
 
 func (n *node) initiateTransfer(p peer.ID) {
-	n.runenv.Message(fmt.Sprintf("initiating transfer to %s", p.Pretty()))
+	n.runenv.Message("initiating transfer to %s", p.Pretty())
 
 	stream, err := n.host.NewStream(n.ctx, p, protocolID)
 	if err != nil {


### PR DESCRIPTION
This adds a `secure-channel` test plan, described in https://github.com/libp2p/go-libp2p-noise/issues/32

It just configures a libp2p `Host` using the provided `secure_channel` param and does a transfer of random data (length set by the `payload_size` param) from one peer to another.

Valid `secure_channel` values are `secio`, `tls`, and `noise`.

TODO:
- [ ] add README for plan
- [x] re-enable docker & swarm executors in manifest