### PR TITLE
fix bugs when parsing default test case params

### DIFF
--- a/manifests/example.toml
+++ b/manifests/example.toml
@@ -50,6 +50,9 @@ instances = { min = 1, max = 200, default = 1 }
   param1 = { type = "int", desc = "some param 1", unit = "widgets", default=1 }
   param2 = { type = "int", desc = "some param 2", unit = "widgets", default=2 }
   param3 = { type = "int", desc = "some param 3", unit = "widgets", default=3 }
+  param4 = { type = "string", desc = "some param 4", default="foo" }
+  param5 = { type = "int", desc = "a param with no default" }
+
 
 [[testcases]]
 name = "sync"

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -380,6 +380,13 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, output io.Wri
 	// Create a coalesced configuration for test case parameters.
 	defaultParams := make(map[string]string, len(tcase.Parameters))
 	for n, v := range tcase.Parameters {
+		if v.Default == nil {
+			continue
+		}
+		if s, ok := v.Default.(string); ok {
+			defaultParams[n] = s
+			continue
+		}
 		data, err := json.Marshal(v.Default)
 		if err != nil {
 			logging.S().Warnf("failed to parse test case parameter; ignoring; name=%s, value=%v, err=%s", n, v, err)


### PR DESCRIPTION
This fixes two bugs around parsing default params. Unless overridden by a composition or at the command line, string params are getting parsed surrounded by `"`  chars, e.g. `"foo"` instead of `foo`, and params with no default value are getting parsed as the string `null`.

This just checks if the `Default` value is nil or already a string before parsing.

I didn't add tests, but I did update the `example/params` test definition with params  that demonstrate the bug.  Before the patch, you get output like

```
   0.2341s    MESSAGE << instance  10 >> key: param4, value: "foo"
   0.2343s    MESSAGE << instance  10 >> key: param5, value: null
```

and afterwards you get

```
   0.4090s    MESSAGE << instance   4 >> key: param4, value: foo
```

and no value printed for `param5` that doesn't have a default set.