### PR TITLE
sync: optimise barrier logic to avoid polling.

### DIFF
--- a/sdk/sync/redis_bench_test.go
+++ b/sdk/sync/redis_bench_test.go
@@ -18,8 +18,8 @@ func BenchmarkBarrier(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		state := State(fmt.Sprintf("yoda-%d", n))
 
-		// simulate 50000 instances, each signalling entry, and waiting for all others
-		total := 50000
+		// simulate 1000 instances, each signalling entry, and waiting for all others
+		total := 1000
 
 		var wg sync.WaitGroup
 		for i := 0; i < total; i++ {

--- a/sdk/sync/redis_bench_test.go
+++ b/sdk/sync/redis_bench_test.go
@@ -1,0 +1,44 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func BenchmarkBarrier(b *testing.B) {
+	b.ReportAllocs()
+
+	close := ensureRedis(b)
+	defer close()
+
+	runenv := randomRunEnv()
+
+	for n := 0; n < b.N; n++ {
+		state := State(fmt.Sprintf("yoda-%d", n))
+
+		// simulate 50000 instances, each signalling entry, and waiting for all others
+		total := 50000
+
+		var wg sync.WaitGroup
+		for i := 0; i < total; i++ {
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				watcher, writer := MustWatcherWriter(context.Background(), runenv)
+				defer watcher.Close()
+				defer writer.Close()
+
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				writer.SignalEntry(ctx, state)
+				<-watcher.Barrier(ctx, state, int64(total))
+			}()
+		}
+		wg.Wait()
+	}
+}

--- a/sdk/sync/redis_test.go
+++ b/sdk/sync/redis_test.go
@@ -25,8 +25,8 @@ func init() {
 
 // Check if there's a running instance of redis, or start it otherwise. If we
 // start an ad-hoc instance, the close function will terminate it.
-func ensureRedis(t *testing.T) (close func()) {
-	t.Helper()
+func ensureRedis(tb testing.TB) (close func()) {
+	tb.Helper()
 
 	// Try to obtain a client; if this fails, we'll attempt to start a redis
 	// instance.
@@ -38,20 +38,20 @@ func ensureRedis(t *testing.T) (close func()) {
 
 	cmd := exec.Command("redis-server", "-")
 	if err := cmd.Start(); err != nil {
-		t.Fatalf("failed to start redis: %s", err)
+		tb.Fatalf("failed to start redis: %s", err)
 	}
 
 	time.Sleep(1 * time.Second)
 
 	// Try to obtain a client again.
 	if client, err = redisClient(context.Background()); err != nil {
-		t.Fatalf("failed to obtain redis client despite starting instance: %v", err)
+		tb.Fatalf("failed to obtain redis client despite starting instance: %v", err)
 	}
 	defer client.Close()
 
 	return func() {
 		if err := cmd.Process.Kill(); err != nil {
-			t.Fatalf("failed while stopping test-scoped redis: %s", err)
+			tb.Fatalf("failed while stopping test-scoped redis: %s", err)
 		}
 	}
 }

--- a/sdk/sync/types.go
+++ b/sdk/sync/types.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -27,6 +28,12 @@ type State string
 // Key gets the key, contextualized to the parent.
 func (s State) Key(parent string) string {
 	return strings.Join([]string{parent, "states", string(s)}, ":")
+}
+
+// BarrierChannel gets the pubsub channel to subscribe to receive relevant
+// barrier advisory signals.
+func (s State) BarrierChannel(parent string, target int64) string {
+	return strings.Join([]string{parent, "states", string(s), "barriers", strconv.Itoa(int(target))}, ":")
 }
 
 // AssertType errors if the value doesn't match the expected type.

--- a/sdk/sync/watch.go
+++ b/sdk/sync/watch.go
@@ -30,7 +30,10 @@ func NewWatcher(ctx context.Context, runenv *runtime.RunEnv) (w *Watcher, err er
 	if err != nil {
 		return nil, fmt.Errorf("during redisClient: %w", err)
 	}
+	return NewWatcherWithClient(ctx, client, runenv)
+}
 
+func NewWatcherWithClient(ctx context.Context, client *redis.Client, runenv *runtime.RunEnv) (w *Watcher, err error) {
 	prefix := basePrefix(runenv)
 	w = &Watcher{
 		re:     runenv,
@@ -140,7 +143,7 @@ func (w *Watcher) Barrier(ctx context.Context, state State, required int64) <-ch
 		switch {
 		case err != nil && err != redis.Nil:
 			resCh <- fmt.Errorf("failed to get value of state: %w", err)
-			return 0, true
+			return 0, false
 		case curr >= required:
 			resCh <- nil
 			return curr, true

--- a/sdk/sync/write.go
+++ b/sdk/sync/write.go
@@ -55,7 +55,10 @@ func NewWriter(ctx context.Context, runenv *runtime.RunEnv) (w *Writer, err erro
 	if err != nil {
 		return nil, err
 	}
+	return NewWriterWithClient(ctx, client, runenv)
+}
 
+func NewWriterWithClient(ctx context.Context, client *redis.Client, runenv *runtime.RunEnv) (w *Writer, err error) {
 	exitCtx, cancel := context.WithCancel(context.Background())
 	w = &Writer{
 		client:       client,


### PR DESCRIPTION
Closes https://github.com/ipfs/testground/issues/663.

Inspired by the [RedissonCountDownLatch](https://github.com/redisson/redisson/blob/master/redisson/src/main/java/org/redisson/RedissonCountDownLatch.java).

When setting a Barrier on a state, we:

1. Subscribe to a channel `<root>/states/<state_name>/barriers/<desired_value>`.
2. GET the value, if >= `desired_value`, cancel the subscription and return.
3. Else, wait until a message is received in the subscription. When a message is received, perform another GET to confirm consistency, cancel the subscription, and return.

When signalling entry on a state, we:

1. `INCR` the value of the state.
2. Publish the new value to channel: `<root>/states/<state_name>/barriers/<new_value>`.