### PR TITLE
Influx metrics -- spike pushing metrics immediately

### DIFF
--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -104,6 +104,12 @@ type ClusterK8sRunnerConfig struct {
 	// Resources requested for each pod from the Kubernetes cluster
 	PodResourceMemory string `toml:"pod_resource_memory"`
 	PodResourceCPU    string `toml:"pod_resource_cpu"`
+
+	// How to reach influxdb
+	InfluxURL    string `toml:"influx_url"`
+	InfluxToken  string `toml:"influx_token"`
+	InfluxOrg    string `toml:"influx_org"`
+	InfluxBucket string `toml:"influx_bucket"`
 }
 
 // ClusterK8sRunner is a runner that creates a Docker service to launch as
@@ -154,6 +160,10 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 		TestSidecar:       true,
 		TestOutputsPath:   "/outputs",
 		TestStartTime:     time.Now(),
+		TestInfluxURL:     cfg.InfluxURL,
+		TestInfluxToken:   cfg.InfluxToken,
+		TestInfluxOrg:     cfg.InfluxOrg,
+		TestInfluxBucket:  cfg.InfluxBucket,
 	}
 
 	// currently weave is not releaasing IP addresses upon container deletion - we get errors back when trying to

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -39,7 +39,13 @@ type LocalExecutableRunner struct {
 }
 
 // LocalExecutableRunnerCfg is the configuration struct for this runner.
-type LocalExecutableRunnerCfg struct{}
+type LocalExecutableRunnerCfg struct {
+	// How to reach influxdb
+	InfluxURL    string `toml:"influx_url"`
+	InfluxToken  string `toml:"influx_token"`
+	InfluxOrg    string `toml:"influx_org"`
+	InfluxBucket string `toml:"influx_bucket"`
+}
 
 func (r *LocalExecutableRunner) Healthcheck(ctx context.Context, engine api.Engine, ow *rpc.OutputWriter, fix bool) (*api.HealthcheckReport, error) {
 	r.lk.Lock()
@@ -76,6 +82,8 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 		name = plan.Name
 	)
 
+	cfg := *input.RunnerConfig.(*LocalExecutableRunnerCfg)
+
 	if seq >= len(plan.TestCases) {
 		return nil, fmt.Errorf("invalid sequence number %d for test %s", seq, name)
 	}
@@ -89,6 +97,10 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 		TestInstanceCount: input.TotalInstances,
 		TestSidecar:       false,
 		TestSubnet:        &runtime.IPNet{IPNet: *localSubnet},
+		TestInfluxURL:     cfg.InfluxURL,
+		TestInfluxToken:   cfg.InfluxToken,
+		TestInfluxOrg:     cfg.InfluxOrg,
+		TestInfluxBucket:  cfg.InfluxBucket,
 	}
 
 	// Spawn as many instances as the input parameters require.

--- a/plans/benchmarks/go.mod
+++ b/plans/benchmarks/go.mod
@@ -9,8 +9,10 @@ replace (
 
 require (
 	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/influxdata/influxdb-client-go v1.0.0
 	github.com/ipfs/testground/sdk/runtime v0.3.0
 	github.com/ipfs/testground/sdk/sync v0.3.0
+	github.com/kubernetes/client-go v11.0.0+incompatible // indirect
 	github.com/multiformats/go-multihash v0.0.13 // indirect
 	github.com/prometheus/client_golang v1.4.1
 )

--- a/sdk/runtime/runenv.go
+++ b/sdk/runtime/runenv.go
@@ -30,6 +30,10 @@ const (
 	EnvTestStartTime          = "TEST_START_TIME"
 	EnvTestSubnet             = "TEST_SUBNET"
 	EnvTestTag                = "TEST_TAG"
+	EnvTestInfluxURL          = "TEST_INFLUX_URL"
+	EnvTestInfluxToken        = "TEST_INFLUX_TOKEN"
+	EnvTestInfluxOrg          = "TEST_INFLUX_ORG"
+	EnvTestInfluxBucket       = "TEST_INFLUX_BUCKET"
 )
 
 type IPNet struct {
@@ -94,6 +98,12 @@ type RunParams struct {
 	// This will be 127.1.0.0/16 when using the local exec runner.
 	TestSubnet    *IPNet    `json:"network,omitempty"`
 	TestStartTime time.Time `json:"start_time,omitempty"`
+
+	// InfluxDB for metrics collection
+	TestInfluxURL    string `json:"influx_url,omitempty"`
+	TestInfluxToken  string `json:"influx_token,omitempty"`
+	TestInfluxOrg    string `json:"influx_org,omitempty"`
+	TestInfluxBucket string `json:"influx_bucket,omitempty"`
 }
 
 // RunEnv encapsulates the context for this test run.
@@ -169,6 +179,10 @@ func (re *RunParams) ToEnvVars() map[string]string {
 		EnvTestStartTime:          re.TestStartTime.Format(time.RFC3339),
 		EnvTestSubnet:             re.TestSubnet.String(),
 		EnvTestTag:                re.TestTag,
+		EnvTestInfluxURL:          re.TestInfluxURL,
+		EnvTestInfluxToken:        re.TestInfluxToken,
+		EnvTestInfluxOrg:          re.TestInfluxOrg,
+		EnvTestInfluxBucket:       re.TestInfluxBucket,
 	}
 
 	return out
@@ -249,6 +263,10 @@ func ParseRunParams(env []string) (*RunParams, error) {
 		TestStartTime:          toTime(EnvTestStartTime),
 		TestSubnet:             toNet(m[EnvTestSubnet]),
 		TestTag:                m[EnvTestTag],
+		TestInfluxURL:          m[EnvTestInfluxURL],
+		TestInfluxToken:        m[EnvTestInfluxToken],
+		TestInfluxOrg:          m[EnvTestInfluxOrg],
+		TestInfluxBucket:       m[EnvTestInfluxBucket],
 	}, nil
 }
 


### PR DESCRIPTION
Alternative to #826.

---

One possible strategy for https://github.com/ipfs/testground/issues/755 

maybe push into influx db directly from plans.
But this would work better if influxdb was accessible in the cluster, much as we do with prometheus/pushgateway now. Runs like this:

```
./testground run single benchmarks/all \
--builder docker:go \
--build-cfg push_registry=true \
--build-cfg registry_type=aws \
--runner cluster:k8s \
--run-cfg influx_url=https://us-west-2-1.aws.cloud2.influxdata.com \
--run-cfg influx_token=XXXXXXXXXX  \
--run-cfg influx_org=YYYYYYYYYYYY \
--run-cfg influx_bucket=ZZZZZZZZZZZ \
--instances 100 \
--collect
```

As you might expect this fails completely when the sidecar is active, although this would work alright if configured to use influxdb in the cluster or if we configured the sidecar to permit this traffic. However, if the sidecar is disabled, this does push metrics into an influxdb cloud.