### PR TITLE
influx collect -- spike deferring metric push until after test completes

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -55,13 +55,18 @@ func collectCommand(c *cli.Context) error {
 		return err
 	}
 
-	return collect(ctx, api, runner, id, output)
+	return collect(ctx, c, api, runner, id, output)
 }
 
-func collect(ctx context.Context, cl *client.Client, runner string, runid string, outputFile string) error {
+func collect(ctx context.Context, c *cli.Context, cl *client.Client, runner string, runid string, outputFile string) error {
+	comp, err := createSingletonComposition(c)
+	if err != nil {
+		return err
+	}
 	req := &client.OutputsRequest{
-		Runner: runner,
-		RunID:  runid,
+		Composition: *comp,
+		Runner:      runner,
+		RunID:       runid,
 	}
 
 	resp, err := cl.CollectOutputs(ctx, req)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -201,5 +201,5 @@ func doRun(c *cli.Context, comp *api.Composition) (err error) {
 		collectFile = fmt.Sprintf("%s.tgz", rout.RunID)
 	}
 
-	return collect(ctx, cl, comp.Global.Runner, rout.RunID, collectFile)
+	return collect(ctx, c, cl, comp.Global.Runner, rout.RunID, collectFile)
 }

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/imdario/mergo v0.3.8
+	github.com/influxdata/influxdb-client-go v1.0.0
 	github.com/ipfs/testground/sdk/runtime v0.3.0
 	github.com/ipfs/testground/sdk/sync v0.3.0
 	github.com/kubernetes/client-go v11.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,10 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/influxdata/influxdb-client-go v1.0.0 h1:SfZUHnqqXn5oPoPZFt138NnFiQPLIgM9GZ3VOkj6ig4=
+github.com/influxdata/influxdb-client-go v1.0.0/go.mod h1:9ESzlV5grLYaHA6wK2SSKlZr+gE3cxH2Q6pvRcASuVY=
+github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
+github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/ipfs/go-cid v0.0.3 h1:UIAh32wymBpStoe83YCzwVQQ5Oy/H0FdxvUS6DJDzms=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/testground v0.1.0/go.mod h1:9obuj1h0ueQuJ5zV5ro69NwU3AHAIw7FXYT1DOj3Ygs=

--- a/pkg/api/engine.go
+++ b/pkg/api/engine.go
@@ -18,7 +18,7 @@ type Engine interface {
 
 	DoBuild(context.Context, *Composition, *rpc.OutputWriter) ([]*BuildOutput, error)
 	DoRun(context.Context, *Composition, *rpc.OutputWriter) (*RunOutput, error)
-	DoCollectOutputs(ctx context.Context, runner string, runID string, ow *rpc.OutputWriter) error
+	DoCollectOutputs(ctx context.Context, comp *Composition, runner string, runID string, ow *rpc.OutputWriter) error
 	DoTerminate(ctx context.Context, runner string, ow *rpc.OutputWriter) error
 	DoHealthcheck(ctx context.Context, runner string, fix bool, ow *rpc.OutputWriter) (*HealthcheckReport, error)
 

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -32,8 +32,9 @@ type CollectResponse struct {
 }
 
 type OutputsRequest struct {
-	Runner string `json:"runner"`
-	RunID  string `json:"run_id"`
+	Composition api.Composition `json:"composition"`
+	Runner      string          `json:"runner"`
+	RunID       string          `json:"run_id"`
 }
 
 type TerminateRequest struct {

--- a/pkg/daemon/outputs.go
+++ b/pkg/daemon/outputs.go
@@ -32,7 +32,7 @@ func (srv *Daemon) outputsHandler(engine api.Engine) func(w http.ResponseWriter,
 			tgw.WriteResult(result)
 		}()
 
-		err = engine.DoCollectOutputs(r.Context(), req.Runner, req.RunID, tgw)
+		err = engine.DoCollectOutputs(r.Context(), &req.Composition, req.Runner, req.RunID, tgw)
 		if err != nil {
 			log.Warnw("collect outputs error", "err", err.Error())
 			return

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -455,7 +455,7 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, ow *rpc.Outpu
 	return out, err
 }
 
-func (e *Engine) DoCollectOutputs(ctx context.Context, runner string, runID string, ow *rpc.OutputWriter) error {
+func (e *Engine) DoCollectOutputs(ctx context.Context, comp *api.Composition, runner string, runID string, ow *rpc.OutputWriter) error {
 	run, ok := e.runners[runner]
 	if !ok {
 		return fmt.Errorf("unknown runner: %s", runner)
@@ -465,6 +465,7 @@ func (e *Engine) DoCollectOutputs(ctx context.Context, runner string, runID stri
 
 	// Get the env config for the runner.
 	cfg = cfg.Append(e.envcfg.RunStrategies[runner])
+	cfg = cfg.Append(comp.Global.RunConfig)
 
 	// Coalesce all configurations and deserialise into the config type
 	// mandated by the builder.

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -542,7 +542,7 @@ func (c *ClusterK8sRunner) CollectOutputs(ctx context.Context, input *api.Collec
 
 	metricsReader := bufio.NewReader(&metricsbuf)
 
-	go MetricsWalkTarfile(metricsReader, ow, cfg.InfluxURL, cfg.InfluxToken, cfg.InfluxOrg, cfg.InfluxBucket)
+	MetricsWalkTarfile(metricsReader, ow, cfg.InfluxURL, cfg.InfluxToken, cfg.InfluxOrg, cfg.InfluxBucket)
 
 	return nil
 }

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -542,7 +542,7 @@ func (c *ClusterK8sRunner) CollectOutputs(ctx context.Context, input *api.Collec
 
 	metricsReader := bufio.NewReader(&metricsbuf)
 
-	MetricsWalkTarfile(metricsReader, ow, cfg.InfluxURL, cfg.InfluxToken, cfg.InfluxOrg, cfg.InfluxBucket)
+	go MetricsWalkTarfile(metricsReader, ow, cfg.InfluxURL, cfg.InfluxToken, cfg.InfluxOrg, cfg.InfluxBucket)
 
 	return nil
 }

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -520,7 +520,6 @@ func (c *ClusterK8sRunner) CollectOutputs(ctx context.Context, input *api.Collec
 	metrictar := bufio.NewReadWriter(bufio.NewReader(&cbuf), bufio.NewWriter(&cbuf))
 	outbuf := bufio.NewWriter(io.MultiWriter(metrictar, ow.BinaryWriter()))
 
-	defer outbuf.Flush()
 	err = exec.Stream(remotecommand.StreamOptions{
 		Stdout: outbuf,
 	})
@@ -528,8 +527,9 @@ func (c *ClusterK8sRunner) CollectOutputs(ctx context.Context, input *api.Collec
 		log.Warnf("failed to collect results from remote collection command: %v", err)
 		return err
 	}
+	outbuf.Flush()
 
-	MetricsWalkTarfile(metrictar, cfg.InfluxURL, cfg.InfluxToken, cfg.InfluxOrg, cfg.InfluxBucket)
+	MetricsWalkTarfile(metrictar, ow, cfg.InfluxURL, cfg.InfluxToken, cfg.InfluxOrg, cfg.InfluxBucket)
 
 	return nil
 }

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -142,6 +142,8 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 
 	cfg := *input.RunnerConfig.(*ClusterK8sRunnerConfig)
 
+	ow.Info("url in run", cfg.InfluxURL)
+
 	podResourceCPU := resource.MustParse(cfg.PodResourceCPU)
 	podResourceMemory := resource.MustParse(cfg.PodResourceMemory)
 
@@ -459,6 +461,7 @@ func (c *ClusterK8sRunner) CollectOutputs(ctx context.Context, input *api.Collec
 	c.initPool()
 
 	cfg := *input.RunnerConfig.(*ClusterK8sRunnerConfig)
+	ow.Info("url in collectoutputs", cfg.InfluxURL)
 
 	log := ow.With("runner", "cluster:k8s", "run_id", input.RunID)
 	err := c.ensureCollectOutputsPod(ctx)

--- a/pkg/runner/outputs_metrics.go
+++ b/pkg/runner/outputs_metrics.go
@@ -83,7 +83,7 @@ func eventRecorder(rowCh chan logRow, doneCh chan int, url string, token string,
 func MetricsWalkTarfile(src io.Reader, ow *rpc.OutputWriter, url string, token string, org string, bucket string) {
 	rowCh := make(chan logRow)
 	doneCh := make(chan int)
-	ow.Info("Uploading events to %s, %url")
+	ow.Info("Uploading events to %s", url)
 	go eventRecorder(rowCh, doneCh, url, token, org, bucket)
 
 	dec, err := gzip.NewReader(src)
@@ -114,9 +114,10 @@ func MetricsWalkTarfile(src io.Reader, ow *rpc.OutputWriter, url string, token s
 		wg.Add(1)
 		go filterMetrics(buf, &wg, rowCh)
 	}
-	ow.Info("waiting for filter metrics")
+	ow.Info("waiting for filterMetrics runners")
 	wg.Wait()
 	close(rowCh)
 	ow.Info("waiting for eventRecorder")
 	<-doneCh
+	ow.Info("metrics upload complete")
 }

--- a/pkg/runner/outputs_metrics.go
+++ b/pkg/runner/outputs_metrics.go
@@ -93,7 +93,7 @@ func eventRecorder(rowCh chan logRow, doneCh chan int, ow *rpc.OutputWriter, url
 		writeApi.WritePoint(pt)
 		// Make sure we flush sometimes.
 		if counter%10000 == 0 {
-			ow.Info("flushing about %d bytes to influxdb", size)
+			ow.Info(fmt.Sprintf("flushing about %d bytes to influxdb", size))
 			writeApi.Flush()
 			size = 0
 		}

--- a/pkg/runner/outputs_metrics.go
+++ b/pkg/runner/outputs_metrics.go
@@ -1,0 +1,117 @@
+package runner
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/ipfs/testground/sdk/runtime"
+
+	"github.com/influxdata/influxdb-client-go"
+)
+
+// This is used to unmarshal the zap log
+// TODO Unmarshal using the actual zap logger
+type logRow struct {
+	Ts      int64          `json:"ts,omitempty"`
+	Msg     string         `json:"msg,omitempty"`
+	GroupId string         `json:"group_id,omitempty"`
+	RunId   string         `json:"run_id,omitempty"`
+	Event   *runtime.Event `json:"event,omitempty"`
+}
+
+// filterMetrics is processes a single run.out file. When it finds a Metric type,
+// it writes the the unmarshaled log row to the channel.
+func filterMetrics(buf *bytes.Buffer, wg *sync.WaitGroup, rowCh chan logRow) {
+	var row logRow
+	scnr := bufio.NewScanner(buf)
+	for scnr.Scan() {
+		err := json.Unmarshal(scnr.Bytes(), &row)
+		if err != nil {
+			continue
+		}
+		event := *(row.Event)
+		if event.Type != runtime.EventTypeMetric {
+			continue
+		}
+		rowCh <- row
+	}
+	wg.Done()
+}
+
+// eventRecorder creates an influx client. This method creates points from log rows it receives from
+// the channel.
+func eventRecorder(rowCh chan logRow, doneCh chan int, url string, token string, org string, bucket string) {
+	client := influxdb2.NewClient(url, token)
+	defer client.Close()
+	writeApi := client.WriteApi(org, bucket)
+	for row := range rowCh {
+		// Pull out the important bits of the log message and create an influxdb event
+		event := *(row.Event)
+		timestamp := row.Ts
+		measurement := fmt.Sprintf("%s (%s)", event.Metric.Name, event.Metric.Unit)
+
+		// Unfortunately? the gitsha, etc is not included in the logs.
+		// Hopefully the GroupID is sufficient to distinguish between code versions
+		tags := map[string]string{
+			"GroupID": row.GroupId,
+			"RunID":   row.RunId,
+		}
+
+		fields := map[string]interface{}{
+			event.Metric.Unit: event.Metric.Value,
+		}
+		pt := influxdb2.NewPoint(measurement, tags, fields, time.Unix(timestamp, 0))
+		writeApi.WritePoint(pt)
+	}
+	writeApi.Flush()
+	close(doneCh)
+
+}
+
+// MetricsWalkTarfilea takes a Reader which should be a gzipped tarball. This is the file format
+// used for outputs. This function creates buffers for each file in the tar file and uses it
+// to generate metrics. The collection tarfile consists of files named "run.out" and "run.err".
+// This method filters out error files.
+func MetricsWalkTarfile(src io.Reader, url string, token string, org string, bucket string) {
+	rowCh := make(chan logRow)
+	doneCh := make(chan int)
+	go eventRecorder(rowCh, doneCh, url, token, org, bucket)
+
+	dec, err := gzip.NewReader(src)
+	if err != nil {
+		panic(err)
+	}
+	defer dec.Close()
+
+	tf := tar.NewReader(dec)
+
+	var wg sync.WaitGroup
+	for hdr, err := tf.Next(); err != io.EOF; hdr, err = tf.Next() {
+		if err != nil {
+			panic(err)
+		}
+
+		fi := hdr.FileInfo()
+		if fi.IsDir() || fi.Name() == "run.err" {
+			continue
+		}
+
+		s := make([]byte, hdr.Size)
+		buf := bytes.NewBuffer(s)
+		_, err := io.Copy(buf, tf)
+		if err != nil {
+			panic(err)
+		}
+		wg.Add(1)
+		go filterMetrics(buf, &wg, rowCh)
+	}
+	wg.Wait()
+	<-doneCh
+}

--- a/pkg/runner/outputs_metrics.go
+++ b/pkg/runner/outputs_metrics.go
@@ -92,12 +92,13 @@ func eventRecorder(rowCh chan logRow, doneCh chan int, ow *rpc.OutputWriter, url
 		pt := influxdb2.NewPoint(measurement, tags, fields, time.Unix(sec, nsec))
 		writeApi.WritePoint(pt)
 		// Make sure we flush sometimes.
-		if counter%10000 == 0 {
+		if counter%5000 == 0 {
 			ow.Info(fmt.Sprintf("flushing about %d bytes to influxdb", size))
 			writeApi.Flush()
 			size = 0
 		}
 	}
+	ow.Info(fmt.Sprintf("final flush, about %d bytes", size))
 	writeApi.Flush()
 	close(doneCh)
 }


### PR DESCRIPTION
I am not confident that this works flawlessly, 

One possible strategy for https://github.com/ipfs/testground/issues/755

Compared to https://github.com/ipfs/testground/pull/825 this more closely resembles the strategy laid out in https://github.com/ipfs/testground/issues/755

This pushes metrics from the collections. It does this by unmarshaling the log files into their original objects and marshaling them again into influxdb points, then pushing them into influxdb.

Just as before, the collections tarball is downloaded for the user to look at offline, but the metrics are extracted and also pushed into influx. 

```
./testground run single benchmarks/all \
--builder docker:go \
--build-cfg push_registry=true \
--build-cfg registry_type=aws \
--runner cluster:k8s \
--run-cfg influx_url=https://us-west-2-1.aws.cloud2.influxdata.com \
--run-cfg influx_token=XXXXXXXXXX  \
--run-cfg influx_org=YYYYYYYYYYYY \
--run-cfg influx_bucket=ZZZZZZZZZZZ \
--instances 100 \
--collect
```

This code could be moved pretty easily to another place, but as a proof of concept, this is functional