### PR TITLE
set build container network to `host` (needed for cluster:k8s runner)

### DIFF
--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -55,7 +55,7 @@ type DockerGoBuilderConfig struct {
 	// Docker image to, if PushRegistry is true.
 	RegistryType string `toml:"registry_type" overridable:"yes"`
 
-	// GoProxyMode specifies one of "on", "off", "custom".
+	// GoProxyMode specifies one of "local", "direct", "remote".
 	//
 	//   * The "local" mode (default) will start a proxy container (if one
 	//     doesn't exist yet) with bridge networking, and will configure the

--- a/pkg/build/golang/docker.go
+++ b/pkg/build/golang/docker.go
@@ -174,8 +174,9 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 	// Make sure we are attached to the testground-build network
 	// so the builder can make use of the goproxy container.
 	opts := types.ImageBuildOptions{
-		Tags:      []string{id, in.BuildID},
-		BuildArgs: args,
+		Tags:        []string{id, in.BuildID},
+		BuildArgs:   args,
+		NetworkMode: "host",
 	}
 
 	// If a docker network was created for the proxy, link it to the build container


### PR DESCRIPTION
Related with: https://github.com/testground/infra/pull/18

Addresses: https://github.com/testground/testground/issues/572

---

We need the `build container` to be on the `host` network, so that it can access a goproxy, which is also attached to the `host` network. Otherwise we have no way of discovering the goproxy service from our cluster (at least I couldn't figure out one).

---

TODO:
- [ ] decide on `default` setup for goproxy.