### PR TITLE
docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ jobs:
   test-linux:
     machine:
       image: ubuntu-1604:201903-01
+      docker_layer_caching: true
     environment:
       GOPATH: "/home/circleci/go"
       GOROOT: "/home/circleci/go"
@@ -106,3 +107,7 @@ jobs:
           name: "test build"
           command: |
             C:\Users\circleci\go\bin\go.exe build ./...
+
+
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,6 @@ jobs:
       - run:
           name: "make lint"
           command: make lint
-      - save_cache:
-          key: v1-pkg-cache
-          paths:
-            - ~/go
   test-linux:
     machine:
       image: ubuntu-1604:201903-01
@@ -87,6 +83,7 @@ jobs:
             mkdir -p $HOME/testground/plans
             ln -s $HOME/project/plans/placebo $HOME/testground/plans/placebo
             go test -v ./...
+      # The cache might be updated due to the build. Save it back.
       - save_cache:
           key: v1-pkg-cache
           paths:
@@ -107,7 +104,3 @@ jobs:
           name: "test build"
           command: |
             C:\Users\circleci\go\bin\go.exe build ./...
-
-
-
-


### PR DESCRIPTION
Enabled docker layer caching on the linux build step. Lets see how much this improves the speed of CI.