### PR TITLE
add debugs for subnet and ip

### DIFF
--- a/pkg/sidecar/k8s_network.go
+++ b/pkg/sidecar/k8s_network.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/testground/sdk-go/sync"
 	"github.com/testground/testground/pkg/docker"
@@ -106,7 +107,10 @@ func (n *K8sNetwork) ConfigureNetwork(ctx context.Context, cfg *sync.NetworkConf
 			CapabilityArgs: capabilityArgs,
 		}
 
-		_, err = n.cninet.AddNetworkList(ctx, netconf, rt)
+		err = retry(3, 2*time.Second, func() error {
+			_, err = n.cninet.AddNetworkList(ctx, netconf, rt)
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("failed to add network through cni plugin: %w", err)
 		}
@@ -224,4 +228,22 @@ func getRedisRoute(handle *netlink.Handle, redisIP net.IP) (*netlink.Route, erro
 	redisRoute := redisRoutes[0]
 
 	return &redisRoute, nil
+}
+
+func retry(attempts int, sleep time.Duration, f func() error) (err error) {
+	for i := 0; ; i++ {
+		err = f()
+		if err == nil {
+			return
+		}
+
+		logging.S().Warnw("got err, waiting to retry", "err", err.Error())
+
+		if i >= (attempts - 1) {
+			break
+		}
+
+		time.Sleep(sleep)
+	}
+	return fmt.Errorf("after %d attempts, last error: %s", attempts, err)
 }

--- a/pkg/sidecar/k8s_network.go
+++ b/pkg/sidecar/k8s_network.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/testground/sdk-go/sync"
 	"github.com/testground/testground/pkg/docker"
 	"github.com/testground/testground/pkg/logging"
-	"github.com/testground/sdk-go/sync"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/vishvananda/netlink"
@@ -85,8 +85,10 @@ func (n *K8sNetwork) ConfigureNetwork(ctx context.Context, cfg *sync.NetworkConf
 			err     error
 		)
 		if cfg.IPv4 == nil {
+			logging.S().Debugw("trying to add a link", "net", n.subnet, "container", n.container.ID)
 			netconf, err = newNetworkConfigList("net", n.subnet)
 		} else {
+			logging.S().Debugw("trying to add a link", "ip", cfg.IPv4.String(), "container", n.container.ID)
 			netconf, err = newNetworkConfigList("ip", cfg.IPv4.String())
 		}
 		if err != nil {


### PR DESCRIPTION
Sidecar occasionally fails with:

```
Apr 24 09:32:14.513973  ERROR   sidecar worker failed: container worker failed: failed to add network through cni plugin: error setting up routes: failed to add route '{0.0.0.0 00000000} via 25.0.0.0 dev eth1': invalid argument     {"host": "unix:///var/run/docker.sock", "container": "87fab28e8ff20f6996c093f40a8e2acb61fd3f10b55114406408cee881e9bc36"}
```

I am not sure what `ip route add` is returning `invalid argument`.