### PR TITLE
generalise redis route to services routes; prepare for InfluxDB addition

### DIFF
--- a/pkg/sidecar/docker_reactor.go
+++ b/pkg/sidecar/docker_reactor.go
@@ -14,10 +14,10 @@ import (
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 
-	"github.com/testground/testground/pkg/docker"
-	"github.com/testground/testground/pkg/logging"
 	"github.com/testground/sdk-go/runtime"
 	"github.com/testground/sdk-go/sync"
+	"github.com/testground/testground/pkg/docker"
+	"github.com/testground/testground/pkg/logging"
 )
 
 // PublicAddr points to an IP address in the public range. It helps us discover
@@ -31,22 +31,24 @@ import (
 var PublicAddr = net.ParseIP("1.1.1.1")
 
 type DockerReactor struct {
-	client  *sync.Client
-	routes  []net.IP
-	manager *docker.Manager
+	client         *sync.Client
+	servicesRoutes []net.IP
+	manager        *docker.Manager
 }
 
 func NewDockerReactor() (Reactor, error) {
 	// TODO: Generalize this to a list of services.
 	wantedRoutes := []string{
 		os.Getenv(EnvRedisHost),
+		os.Getenv(EnvInfluxdbHost),
 	}
 
 	var resolvedRoutes []net.IP
 	for _, route := range wantedRoutes {
 		ip, err := net.ResolveIPAddr("ip4", route)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve host %s: %w", route, err)
+			logging.S().Warnw("failed to resolve host", "host", route, "err", err.Error())
+			continue
 		}
 		resolvedRoutes = append(resolvedRoutes, ip.IP)
 	}
@@ -65,9 +67,9 @@ func NewDockerReactor() (Reactor, error) {
 	client.EnableBackgroundGC(nil)
 
 	return &DockerReactor{
-		client:  client,
-		routes:  resolvedRoutes,
-		manager: docker,
+		client:         client,
+		servicesRoutes: resolvedRoutes,
+		manager:        docker,
 	}, nil
 }
 
@@ -187,7 +189,7 @@ func (d *DockerReactor) handleContainer(ctx context.Context, container *docker.C
 	// TODO: Some of this code could be factored out into helpers.
 
 	var controlRoutes []netlink.Route
-	for _, route := range d.routes {
+	for _, route := range d.servicesRoutes {
 		nlroutes, err := netlinkHandle.RouteGet(route)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve route: %w", err)

--- a/pkg/sidecar/k8s_network.go
+++ b/pkg/sidecar/k8s_network.go
@@ -215,19 +215,19 @@ func newNetworkConfigList(t string, addr string) (*libcni.NetworkConfigList, err
 	}
 }
 
-func getRedisRoute(handle *netlink.Handle, redisIP net.IP) (*netlink.Route, error) {
-	redisRoutes, err := handle.RouteGet(redisIP)
+func getServiceRoute(handle *netlink.Handle, serviceIP net.IP) (*netlink.Route, error) {
+	serviceRoutes, err := handle.RouteGet(serviceIP)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve route to redis: %w", err)
+		return nil, fmt.Errorf("failed to resolve route to service: %w", err)
 	}
 
-	if len(redisRoutes) != 1 {
-		return nil, fmt.Errorf("expected to get only one route to redis, but got %v", len(redisRoutes))
+	if len(serviceRoutes) != 1 {
+		return nil, fmt.Errorf("expected to get only one route to the given service, but got %v", len(serviceRoutes))
 	}
 
-	redisRoute := redisRoutes[0]
+	serviceRoute := serviceRoutes[0]
 
-	return &redisRoute, nil
+	return &serviceRoute, nil
 }
 
 func retry(attempts int, sleep time.Duration, f func() error) (err error) {

--- a/pkg/sidecar/k8s_reactor.go
+++ b/pkg/sidecar/k8s_reactor.go
@@ -184,7 +184,7 @@ func (d *K8sReactor) manageContainer(ctx context.Context, container *docker.Cont
 		return nil, fmt.Errorf("failed to get link by name %s: %w", controlNetworkIfname, err)
 	}
 
-	servicesIPs := []net.IP{}
+	var servicesIPs []net.IP
 
 	for _, route := range d.servicesRoutes {
 		// Get the routes to redis, influxdb, etc... We need to keep these.

--- a/pkg/sidecar/sidecar_linux.go
+++ b/pkg/sidecar/sidecar_linux.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/testground/testground/pkg/logging"
 	"github.com/testground/sdk-go/sync"
+	"github.com/testground/testground/pkg/logging"
 )
 
 const (
-	EnvRedisHost = "REDIS_HOST"
+	EnvRedisHost    = "REDIS_HOST"
+	EnvInfluxdbHost = "INFLUXDB_HOST"
 )
 
 var runners = map[string]func() (Reactor, error){


### PR DESCRIPTION
This will be needed for https://github.com/testground/testground/issues/907 and I can see this generalisation has been done for Docker already.

One change that I am introducing is that the sidecar doesn't panic if it can't resolve the IP of a service - allowing for both required and optional services.

---

This is useful for me, because I also run InfluxDB with almost every cluster, and want to have the route allowed, without having to recompile the sidecar.