### PR TITLE
rename INFLUXDB_ADDR env var to INFLUXDB_URL for correctness.

### DIFF
--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -215,7 +215,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 
 		// Serialize the runenv into env variables to pass to docker.
 		env := conv.ToOptionsSlice(runenv.ToEnvVars())
-		env = append(env, "INFLUXDB_ADDR=http://testground-influxdb:8086")
+		env = append(env, "INFLUXDB_URL=http://testground-influxdb:8086")
 
 		// Set the log level if provided in cfg.
 		if cfg.LogLevel != "" {

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -116,7 +116,7 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 			runenv.TestStartTime = time.Now()
 
 			env := conv.ToOptionsSlice(runenv.ToEnvVars())
-			env = append(env, "INFLUXDB_ADDR=http://localhost:8086")
+			env = append(env, "INFLUXDB_URL=http://localhost:8086")
 
 			ow.Infow("starting test case instance", "plan", input.TestPlan, "group", g.ID, "number", i, "total", total)
 


### PR DESCRIPTION
SDK change implemented here: https://github.com/testground/sdk-go/pull/3/commits/429e8794f3f89424ca497afe4701b3b0a613ac28