### PR TITLE
fix healthcheck feedback to user

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -154,9 +154,11 @@ func (e *Engine) DoBuild(ctx context.Context, comp *api.Composition, basesrc str
 			return nil, fmt.Errorf("healthcheck and fix errored: %w", err)
 		} else if !rep.FixesSucceeded() {
 			return nil, fmt.Errorf("healthcheck fixes failed; aborting:\n%s", rep)
+		} else if !rep.ChecksSucceeded() {
+			ow.Warnf(aurora.Bold(aurora.Yellow("some healthchecks failed, but continuing")).String())
+		} else {
+			ow.Infof(aurora.Bold(aurora.Green("healthcheck: ok")).String())
 		}
-
-		ow.Infof(aurora.Bold(aurora.Green("healthcheck: ok")).String())
 	}
 
 	// This var compiles all configurations to coalesce.
@@ -286,9 +288,11 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, ow *rpc.Outpu
 			return nil, fmt.Errorf("healthcheck and fix errored: %w", err)
 		} else if !rep.FixesSucceeded() {
 			return nil, fmt.Errorf("healthcheck fixes failed; aborting:\n%s", rep)
+		} else if !rep.ChecksSucceeded() {
+			ow.Warnf(aurora.Bold(aurora.Yellow("some healthchecks failed, but continuing")).String())
+		} else {
+			ow.Infof(aurora.Bold(aurora.Green("healthcheck: ok")).String())
 		}
-
-		ow.Infof(aurora.Bold(aurora.Green("healthcheck: ok")).String())
 	}
 
 	// Check if builder and runner are compatible


### PR DESCRIPTION
It looks like we are not accounting for the case where a specific `healthcheck` is failing, but we don't have a `fixer` for it - for example `redis` disappearing on our Kubernetes cluster.

In this case currently we respond to the user that `healthchecks: ok` which is misleading, so I suggest we at least give back a `warning` and continue with the run. (i.e. no change in behaviour)

After seeing the warning the user can call `testground healthcheck --runner cluster:k8s` and get a detailed report on what appears to be broken.