### PR TITLE
fix redis rdb snapshot complaints.

### DIFF
--- a/pkg/runner/local_common.go
+++ b/pkg/runner/local_common.go
@@ -52,7 +52,7 @@ func localCommonHealthcheck(ctx context.Context, hh *healthcheck.Helper, cli *cl
 			ContainerName: "testground-redis",
 			ContainerConfig: &container.Config{
 				Image: "library/redis",
-				Cmd:   []string{"--save", "\"\"", "--appendonly", "no", "--maxclients", "120000"},
+				Cmd:   []string{"--save", "", "--appendonly", "no", "--maxclients", "120000", "--stop-writes-on-bgsave-error", "no"},
 			},
 			HostConfig: &container.HostConfig{
 				PortBindings: exposed,


### PR DESCRIPTION
Fixes #954. It looks like macOS Catalina could be restricting some Docker RDB writes, if the persistence directory is not properly configured. Never seen this on macOS Mojave or Linux.

This PR fixes the `--save ""` option (it's possible that the escaping was not working well), and sets `stop-writes-on-bgsave-error` to `no`.

```
⟩ redis-cli
127.0.0.1:6379> config get *save*
1) "stop-writes-on-bgsave-error"
2) "no"
3) "rdb-save-incremental-fsync"
4) "yes"
5) "rdb-key-save-delay"
6) "0"
7) "save"
8) ""
127.0.0.1:6379> config get *stop*
1) "stop-writes-on-bgsave-error"
2) "no"
127.0.0.1:6379>
```