### PR TITLE
remove aws credentials from sample .env.toml

### DIFF
--- a/env-example.toml
+++ b/env-example.toml
@@ -5,8 +5,6 @@
 # which may be used by several components.
 #
 ["aws"]
-access_key_id = "<aws access key id>"
-secret_access_key = "<aws secret access key>"
 region = "<aws region>"
 
 ["dockerhub"]


### PR DESCRIPTION
I suggest we remove these from the sample `.env.toml`, because it is not normal for users to have to enter these at all.

Usually we pick up the default credentials from the host or the IAM policy.

I personally have never had to specify my credentials in this file, so I am not sure in what use-case one would want to do that.