### PR TITLE
plan create cmd: output location of new test plan.

### DIFF
--- a/pkg/cmd/plan.go
+++ b/pkg/cmd/plan.go
@@ -174,6 +174,7 @@ func createCommand(c *cli.Context) error {
 		}
 		f.Close()
 	}
+	fmt.Println("new test plan created under:", pdir)
 	return nil
 }
 


### PR DESCRIPTION
I've updated the quickstart docs accordingly:

![image](https://user-images.githubusercontent.com/1101242/81318744-9b13b980-9086-11ea-8eea-3a031c663308.png)
