### PR TITLE
example/sync: tidy up; remove superfluous pubsub.

### DIFF
--- a/plans/example/sync.go
+++ b/plans/example/sync.go
@@ -11,72 +11,77 @@ import (
 )
 
 // ExampleSync demonstrates synchronization between instances in the test group.
-// The backend for synchronization is a redis queue, but this detail is abstracted
-// away from us as the Watcher.
 //
-// In this example, the first instance to write becomes the leader of the test.
+// In this example, the first instance to signal enrollment becomes the leader
+// of the test case.
+//
 // The leader waits until all the followers have reached the state "ready"
-// then, the followers wait for a signal from the leader to start.
+// then, the followers wait for a signal from the leader to be released.
 func ExampleSync(runenv *runtime.RunEnv) error {
 	var (
-		readyState = sync.State("ready")
-		startState = sync.State("start")
+		enrolledState = sync.State("enrolled")
+		readyState    = sync.State("ready")
+		releasedState = sync.State("released")
+
+		ctx = context.Background()
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
-
+	// instantiate a sync service client, binding it to the RunEnv.
 	client := sync.MustBoundClient(ctx, runenv)
 	defer client.Close()
 
+	// instantiate a network client; see 'Traffic shaping' in the docs.
 	netclient := network.NewClient(client, runenv)
-	runenv.RecordMessage("Waiting for network initialization")
+	runenv.RecordMessage("waiting for network initialization")
 
+	// wait for the network to initialize; this should be pretty fast.
 	netclient.MustWaitNetworkInitialized(ctx)
-	runenv.RecordMessage("Network initilization complete")
+	runenv.RecordMessage("network initilization complete")
 
-	topic := sync.NewTopic("messages", "")
+	// signal entry in the 'enrolled' state, and obtain a sequence number.
+	seq := client.MustSignalEntry(ctx, enrolledState)
 
-	seq, err := client.Publish(ctx, topic, runenv.TestRun)
-	if err != nil {
-		return err
-	}
+	runenv.RecordMessage("my sequence ID: %d", seq)
 
-	runenv.RecordMessage("My sequence ID: %d", seq)
-
+	// if we're the first instance to signal, we'll become the LEADER.
 	if seq == 1 {
-		runenv.RecordMessage("I'm the boss.")
+		runenv.RecordMessage("i'm the leader.")
 		numFollowers := runenv.TestInstanceCount - 1
 
-		runenv.RecordMessage("Waiting for %d instances to become ready", numFollowers)
+		// let's wait for the followers to signal.
+		runenv.RecordMessage("waiting for %d instances to become ready", numFollowers)
 		err := <-client.MustBarrier(ctx, readyState, numFollowers).C
 		if err != nil {
 			return err
 		}
 
-		runenv.RecordMessage("The followers are all ready")
-		runenv.RecordMessage("Ready...")
+		runenv.RecordMessage("the followers are all ready")
+		runenv.RecordMessage("ready...")
 		time.Sleep(1 * time.Second)
-		runenv.RecordMessage("Set...")
+		runenv.RecordMessage("set...")
 		time.Sleep(5 * time.Second)
-		runenv.RecordMessage("Go!")
+		runenv.RecordMessage("go, release followers!")
 
-		client.MustSignalEntry(ctx, startState)
+		// signal on the 'released' state.
+		client.MustSignalEntry(ctx, releasedState)
 		return nil
 	}
 
 	rand.Seed(time.Now().UnixNano())
-	sleepTime := rand.Intn(10)
-	runenv.RecordMessage("I'm a follower. Signaling ready after %d seconds", sleepTime)
-	time.Sleep(time.Duration(sleepTime) * time.Second)
+	sleep := rand.Intn(5)
+	runenv.RecordMessage("i'm a follower; signalling ready after %d seconds", sleep)
+	time.Sleep(time.Duration(sleep) * time.Second)
+	runenv.RecordMessage("follower signalling now", sleep)
 
+	// signal entry in the 'ready' state.
 	client.MustSignalEntry(ctx, readyState)
 
-	err = <-client.MustBarrier(ctx, startState, 1).C
+	// wait until the leader releases us.
+	err := <-client.MustBarrier(ctx, releasedState, 1).C
 	if err != nil {
 		return err
 	}
 
-	runenv.RecordMessage("Received Start")
+	runenv.RecordMessage("i have been released")
 	return nil
 }

--- a/plans/example/sync.go
+++ b/plans/example/sync.go
@@ -71,7 +71,7 @@ func ExampleSync(runenv *runtime.RunEnv) error {
 	sleep := rand.Intn(5)
 	runenv.RecordMessage("i'm a follower; signalling ready after %d seconds", sleep)
 	time.Sleep(time.Duration(sleep) * time.Second)
-	runenv.RecordMessage("follower signalling now", sleep)
+	runenv.RecordMessage("follower signalling now")
 
 	// signal entry in the 'ready' state.
 	client.MustSignalEntry(ctx, readyState)


### PR DESCRIPTION
I also updated the docs at https://docs.testground.ai/writing-test-plans/synchronization.

--

* no need to use a topic to get a seq; we can use a state.
* it's misleading to use the term "start" when that state actually ends the test.
* no need to set a deadline on the context; we can simplify.
