### PR TITLE
cleanup: remove cruft from sample manifest.toml files.

### DIFF
--- a/plans/benchmarks/manifest.toml
+++ b/plans/benchmarks/manifest.toml
@@ -6,14 +6,9 @@ runner = "local:exec"
 
 [builders."docker:go"]
 enabled = true
-go_version = "1.13"
-module_path = "github.com/testground/testground/plans/benchmarks"
-exec_pkg = "."
 
 [builders."exec:go"]
 enabled = true
-module_path = "github.com/testground/testground/plans/benchmarks"
-exec_pkg = "."
 
 [runners."local:docker"]
 enabled = true

--- a/plans/benchmarks/manifest.toml
+++ b/plans/benchmarks/manifest.toml
@@ -1,7 +1,4 @@
 name = "benchmarks"
-# hashicorp/go-getter URLs, so in the future we can support fetching test plans
-# from GitHub.
-source_path = "file://${TESTGROUND_SRCDIR}/plans/benchmarks"
 
 [defaults]
 builder = "exec:go"

--- a/plans/example/manifest.toml
+++ b/plans/example/manifest.toml
@@ -1,7 +1,4 @@
 name = "example"
-# hashicorp/go-getter URLs, so in the future we can support fetching test plans
-# from GitHub.
-source_path = "file://${TESTGROUND_SRCDIR}/plans/example"
 
 [defaults]
 builder = "exec:go"

--- a/plans/example/manifest.toml
+++ b/plans/example/manifest.toml
@@ -6,14 +6,9 @@ runner = "local:exec"
 
 [builders."docker:go"]
 enabled = true
-go_version = "1.13"
-module_path = "github.com/testground/testground/plans/example"
-exec_pkg = "."
 
 [builders."exec:go"]
 enabled = true
-module_path = "github.com/testground/testground/plans/example"
-exec_pkg = "."
 
 [runners."local:docker"]
 enabled = true

--- a/plans/network/manifest.toml
+++ b/plans/network/manifest.toml
@@ -6,14 +6,9 @@ runner = "local:exec"
 
 [builders."docker:go"]
 enabled = true
-go_version = "1.13"
-module_path = "github.com/testground/testground/plans/network"
-exec_pkg = "."
 
 [builders."exec:go"]
 enabled = true
-module_path = "github.com/testground/testground/plans/network"
-exec_pkg = "."
 
 [runners."local:docker"]
 enabled = true

--- a/plans/network/manifest.toml
+++ b/plans/network/manifest.toml
@@ -1,7 +1,4 @@
 name = "network"
-# hashicorp/go-getter URLs, so in the future we can support fetching test plans
-# from GitHub.
-source_path = "file://${TESTGROUND_SRCDIR}/plans/network"
 
 [defaults]
 builder = "exec:go"

--- a/plans/placebo/manifest.toml
+++ b/plans/placebo/manifest.toml
@@ -1,7 +1,4 @@
 name = "placebo"
-# hashicorp/go-getter URLs, so in the future we can support fetching test plans
-# from GitHub.
-source_path = "file://${TESTGROUND_SRCDIR}/plans/placebo"
 
 [defaults]
 builder = "exec:go"

--- a/plans/placebo/manifest.toml
+++ b/plans/placebo/manifest.toml
@@ -6,14 +6,9 @@ runner = "local:exec"
 
 [builders."docker:go"]
 enabled = true
-go_version = "1.13"
-module_path = "github.com/testground/testground/plans/placebo"
-exec_pkg = "."
 
 [builders."exec:go"]
 enabled = true
-module_path = "github.com/testground/testground/plans/placebo"
-exec_pkg = "."
 
 [runners."local:docker"]
 enabled = true

--- a/plans/verify/manifest.toml
+++ b/plans/verify/manifest.toml
@@ -6,9 +6,6 @@ runner = "local:docker"
 
 [builders."docker:go"]
 enabled = true
-go_version = "1.13"
-module_path = "github.com/testground/testground/plans/placebo"
-exec_pkg = "."
 
 [runners."local:docker"]
 enabled = true

--- a/plans/verify/manifest.toml
+++ b/plans/verify/manifest.toml
@@ -1,7 +1,4 @@
 name = "verify"
-# hashicorp/go-getter URLs, so in the future we can support fetching test plans
-# from GitHub.
-source_path = "file://${TESTGROUND_SRCDIR}/plans/verify"
 
 [defaults]
 builder = "docker:go"


### PR DESCRIPTION
* `source_path`: needed no longer longer. Leftover from https://github.com/testground/testground/pull/849.
* builder configuration:
   * `module_path` only needed if we're initialising a fresh gomod, which we aren't.
   * `exec_path` not needed as go toolchain defaults to `.`
   * overriding `go_version` not needed either