### PR TITLE
flatten pkg/build package.

### DIFF
--- a/pkg/build/deps_go.go
+++ b/pkg/build/deps_go.go
@@ -1,4 +1,4 @@
-package golang
+package build
 
 import (
 	"context"

--- a/pkg/build/deps_go_test.go
+++ b/pkg/build/deps_go_test.go
@@ -1,4 +1,4 @@
-package golang
+package build
 
 import (
 	"fmt"

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -1,4 +1,4 @@
-package golang
+package build
 
 import (
 	"context"

--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -1,4 +1,4 @@
-package golang
+package build
 
 import (
 	"context"

--- a/pkg/build/selector_test.go
+++ b/pkg/build/selector_test.go
@@ -1,4 +1,4 @@
-package golang_test
+package build_test
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/testground/testground/pkg/api"
-	"github.com/testground/testground/pkg/build/golang"
+	"github.com/testground/testground/pkg/build"
 	"github.com/testground/testground/pkg/config"
 	"github.com/testground/testground/pkg/engine"
 	"github.com/testground/testground/pkg/rpc"
@@ -31,7 +31,7 @@ func TestBuildSelector(t *testing.T) {
 		os.RemoveAll(basedir)
 	})
 
-	err = copy.Copy("../../../plans/placebo", plandir)
+	err = copy.Copy("../../plans/placebo", plandir)
 	require.NoError(err)
 
 	env := &config.EnvConfig{}
@@ -39,7 +39,7 @@ func TestBuildSelector(t *testing.T) {
 	require.NoError(err)
 
 	cfg := &engine.EngineConfig{
-		Builders:  []api.Builder{new(golang.DockerGoBuilder), new(golang.ExecGoBuilder)},
+		Builders:  []api.Builder{new(build.DockerGoBuilder), new(build.ExecGoBuilder)},
 		Runners:   []api.Runner{},
 		EnvConfig: env,
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/testground/testground/pkg/api"
-	"github.com/testground/testground/pkg/build/golang"
+	"github.com/testground/testground/pkg/build"
 	"github.com/testground/testground/pkg/config"
 	"github.com/testground/testground/pkg/rpc"
 	"github.com/testground/testground/pkg/runner"
@@ -19,8 +19,8 @@ import (
 
 // AllBuilders enumerates all builders known to the system.
 var AllBuilders = []api.Builder{
-	&golang.DockerGoBuilder{},
-	&golang.ExecGoBuilder{},
+	&build.DockerGoBuilder{},
+	&build.ExecGoBuilder{},
 }
 
 // AllRunners enumerates all runners known to the system.


### PR DESCRIPTION
Shuffle around a few things and flatten the `pkg/build` package to make it symmetric to `pkg/runner`.