### PR TITLE
extract `default` network name

### DIFF
--- a/pkg/sidecar/k8s_network.go
+++ b/pkg/sidecar/k8s_network.go
@@ -17,6 +17,10 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+const (
+	defaultDataNetwork = "default"
+)
+
 type k8sLink struct {
 	*NetlinkLink
 	IPv4, IPv6 *net.IPNet
@@ -40,8 +44,8 @@ func (n *K8sNetwork) Close() error {
 }
 
 func (n *K8sNetwork) ConfigureNetwork(ctx context.Context, cfg *sync.NetworkConfig) error {
-	if cfg.Network != "default" {
-		return errors.New("configured network is not default")
+	if cfg.Network != defaultDataNetwork {
+		return fmt.Errorf("configured network is not `%s`", defaultDataNetwork)
 	}
 
 	link, online := n.activeLinks[cfg.Network]

--- a/pkg/sidecar/sidecar_linux.go
+++ b/pkg/sidecar/sidecar_linux.go
@@ -67,7 +67,7 @@ func handler(ctx context.Context, instance *Instance) error {
 
 	// Network configuration loop.
 	err := instance.Network.ConfigureNetwork(ctx, &sync.NetworkConfig{
-		Network: "default",
+		Network: defaultDataNetwork,
 		Enable:  true,
 	})
 


### PR DESCRIPTION
`default` is a special name of the only data network we currently set up and allow traffic shaping on.

Therefore it is best if we extract it and amend the docs at https://docs.testground.ai/traffic-shaping#configure-traffic-shaping to use `network.DefaultDataNetwork` and explain a bit better what this value is, together with `CallbackState`.