### PR TITLE
relax latency expectations on network/ping-pong test

### DIFF
--- a/plans/network/main.go
+++ b/plans/network/main.go
@@ -182,17 +182,17 @@ func pingpong(runenv *runtime.RunEnv) error {
 
 		return nil
 	}
-	err = pingPong("200", 200*time.Millisecond, 215*time.Millisecond)
+	err = pingPong("200", 200*time.Millisecond, 300*time.Millisecond)
 	if err != nil {
 		return err
 	}
 
-	config.Default.Latency = 10 * time.Millisecond
+	config.Default.Latency = 50 * time.Millisecond
 	config.CallbackState = "latency-reduced"
 	netclient.MustConfigureNetwork(ctx, config)
 
 	runenv.RecordMessage("ping pong")
-	err = pingPong("10", 20*time.Millisecond, 35*time.Millisecond)
+	err = pingPong("100", 100*time.Millisecond, 200*time.Millisecond)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
@hacdias reported that he got failures on `local:docker`, such as:

```
expected an RTT between 20ms and 35ms, got 48.096866ms	{"req_id": "3601308d"}
```

Therefore I am relaxing a bit the RTT expectation to be within 100ms - this should work consistently on CI environments and locally I guess.