### PR TITLE
add --link-sdk flag to run composition cmd

### DIFF
--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -13,6 +13,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var linkSdkUsage = "links the test plan against a local SDK. The full `DIR_PATH`, or the NAME can be supplied, " +
+	"in the latter case, the testground client will expect to find the SDK under $TESTGROUND_HOME/sdks/NAME"
+
 var BuildCommand = cli.Command{
 	Name:  "build",
 	Usage: "request the daemon to build a test plan",
@@ -36,7 +39,7 @@ var BuildCommand = cli.Command{
 				},
 				&cli.StringFlag{
 					Name:  "link-sdk",
-					Usage: "link the test plan against a local SDK; `SDK_NAME` can be a full path, or a directory under $TESTGROUND_HOME/sdks",
+					Usage: linkSdkUsage,
 				},
 			},
 		},
@@ -62,9 +65,8 @@ var BuildCommand = cli.Command{
 					Usage:   "set a dependency mapping",
 				},
 				&cli.StringFlag{
-					Name: "link-sdk",
-					Usage: "links the test plan against a local SDK. The full `DIR_PATH`, or the `NAME` can be supplied," +
-						"In the latter case, the testground client will expect to find the SDK under $TESTGROUND_HOME/sdks/NAME",
+					Name:  "link-sdk",
+					Usage: linkSdkUsage,
 				},
 				&cli.StringFlag{
 					Name:     "plan",

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -24,18 +24,8 @@ var RunCommand = cli.Command{
 			Aliases: []string{"c"},
 			Usage:   "(build and) run a composition",
 			Action:  runCompositionCmd,
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:     "file",
-					Aliases:  []string{"f"},
-					Usage:    "path to a `COMPOSITION`",
-					Required: true,
-				},
-				&cli.BoolFlag{
-					Name:    "write-artifacts",
-					Aliases: []string{"w"},
-					Usage:   "write the resulting build artifacts to the composition file",
-				},
+			Flags: append(
+				BuildCommand.Subcommands[0].Flags, // inject all build single command flags.
 				&cli.BoolFlag{
 					Name:    "ignore-artifacts",
 					Aliases: []string{"i"},
@@ -50,7 +40,7 @@ var RunCommand = cli.Command{
 					Aliases: []string{"o"},
 					Usage:   "write the collection output archive to `FILENAME`",
 				},
-			},
+			),
 		},
 		&cli.Command{
 			Name:    "single",


### PR DESCRIPTION
This PR is:
1. making the usage text for the `--link-sdk` option consistent
2. including the flags for `testground build composition` into `testground run composition`, essentially adding the `link-sdk` flag to `testground run`.
3. removing the common flags between `run compositon` and `build composition`, similar to how we do it for `testground run single` and `testground build single`.