### PR TITLE
extract sysctls into .env.toml ; extract collect-outputs requests in .env.toml

### DIFF
--- a/env-example.toml
+++ b/env-example.toml
@@ -22,8 +22,13 @@ access_token = "docker hub access token"
 #   4. Runner defaults (applied by the runner).
 #
 [runners."cluster:k8s"]
-pod_resource_cpu      = "100m"
-pod_resource_memory   = "100Mi"
+testplan_pod_cpu            = "100m"
+testplan_pod_memory         = "100Mi"
+collect_outputs_pod_cpu     = "100m"
+collect_outputs_pod_memory  = "100Mi"
+sysctls = [
+  "net.core.somaxconn=10000",
+]
 
 [runners."local:docker"]
 ulimits = [

--- a/pkg/cmd/sidecar.go
+++ b/pkg/cmd/sidecar.go
@@ -29,7 +29,7 @@ var SidecarCommand = cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:     "runner",
-			Usage:    "runner that will be scheduling tasks that should be managed by this sidecar; supported: 'local:docker', 'cluster:k8s'",
+			Usage:    "runner that will be scheduling tasks that should be managed by this sidecar; supported: 'docker', 'k8s'",
 			Required: true,
 		},
 		&cli.BoolFlag{


### PR DESCRIPTION
This PR is:
1. extracting `sysctls` into an `.env.toml` file - we want that, so that we can run integration tests on Kubernetes, in environments that don't allow us to set `sysctls`.
2. extracting `collect-outputs` pod requests into `.env.toml` - in the real-world we want to run this with a lot of RAM and CPU, but for test purposes we need fewer resources.