### PR TITLE
fix make test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,9 +111,8 @@ jobs:
       - run:
           name: "make test"
           command: |
-            testground plan import --from $HOME/project/plans/placebo
-            testground plan import --from $HOME/project/plans/example
-            go test -v ./...
+            cd $HOME/project
+            make test
 
   # Tests the k8s runner can successfully submit jobs.
   kind-test:

--- a/Makefile
+++ b/Makefile
@@ -37,5 +37,11 @@ docker-sidecar:
 docker-testground:
 	docker build -t iptestground/testground:edge -f Dockerfile.testground .
 
-test:
+clean:
+	rm -rfi $${TESTGROUND_HOME}/plans/placebo
+	rm -rfi $${TESTGROUND_HOME}/plans/example
+
+test: install
+	testground plan import --from ./plans/placebo || true
+	testground plan import --from ./plans/example || true
 	$(call eachmod,go test -p 1 -v $(GOTFLAGS) ./...)

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,6 @@ docker-sidecar:
 docker-testground:
 	docker build -t iptestground/testground:edge -f Dockerfile.testground .
 
-clean:
-	rm -rfi $${TESTGROUND_HOME}/plans/placebo
-	rm -rfi $${TESTGROUND_HOME}/plans/example
-
 test: install
 	testground plan import --from ./plans/placebo || true
 	testground plan import --from ./plans/example || true


### PR DESCRIPTION
`make test` doesn't work locally unless you have `placebo` and `example` in the `TESTGROUND_HOME` directory.

Therefore I am adding an `testground plan import` prior to the call to `go test` on every module.