### PR TITLE
docker image: pull if not present

### DIFF
--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -673,11 +673,12 @@ func (c *ClusterK8sRunner) createTestplanPod(ctx context.Context, podName string
 			RestartPolicy: v1.RestartPolicyNever,
 			InitContainers: []v1.Container{
 				{
-					Name:    "mkdir-outputs",
-					Image:   "busybox",
-					Args:    []string{"-c", "mkdir -p $TEST_OUTPUTS_PATH"},
-					Command: []string{"sh"},
-					Env:     env,
+					Name:            "mkdir-outputs",
+					Image:           "busybox",
+					ImagePullPolicy: v1.PullIfNotPresent,
+					Args:            []string{"-c", "mkdir -p $TEST_OUTPUTS_PATH"},
+					Command:         []string{"sh"},
+					Env:             env,
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:             sharedVolumeName,
@@ -695,10 +696,11 @@ func (c *ClusterK8sRunner) createTestplanPod(ctx context.Context, podName string
 			},
 			Containers: []v1.Container{
 				{
-					Name:  podName,
-					Image: g.ArtifactPath,
-					Args:  []string{},
-					Env:   env,
+					Name:            podName,
+					Image:           g.ArtifactPath,
+					ImagePullPolicy: v1.PullIfNotPresent,
+					Args:            []string{},
+					Env:             env,
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "pprof",


### PR DESCRIPTION
I was under the impression that this is the default on Kubernetes, but it appears this is not the case, or something weird is going on with the image names.

1. Without this option, we are always pulling `busybox` (for the `mkdir-outputs` init container), resulting in a lot of latency when starting testplan pods.

2. If the tagged test plan image is on the machine, we don't pull it.

---

Note that even if our Docker build cache results in the same image, we are always allocating a unique `buildID` to the testplan images, resulting in Kubernetes pulling images on every testplan run, unless we use the `-w` option and specify exact `artifacts`. I think this is bad, and we have to rethink the tagging of our images.

For example:

Run 1:
```
Successfully built 64748d329558
Successfully tagged 56d6f649fcc6:latest
May 20 13:20:01.474108  INFO    build completed {"req_id": "9aa71882", "build_id": "56d6f649fcc6", "took": "4s"}
May 20 13:20:01.685309  INFO    tagging image   {"req_id": "9aa71882", "build_id": "56d6f649fcc6", "tag": "909427826938.dkr.ecr.eu-west-2.amazonaws.com/testground-eu-west-2-benchmarks:56d6f649fcc6"}
May 20 13:20:01.690947  INFO    pushing image   {"req_id": "9aa71882", "build_id": "56d6f649fcc6", "tag": "909427826938.dkr.ecr.eu-west-2.amazonaws.com/testground-eu-west-2-benchmarks:56d6f649fcc6"}
```

Run 2:
```
Successfully built 64748d329558
Successfully tagged 52c47f83d2da:latest
May 20 13:20:17.142167  INFO    build completed {"req_id": "237b5b1b", "build_id": "52c47f83d2da", "took": "0s"}
May 20 13:20:17.292759  INFO    tagging image   {"req_id": "237b5b1b", "build_id": "52c47f83d2da", "tag": "909427826938.dkr.ecr.eu-west-2.amazonaws.com/testground-eu-west-2-benchmarks:52c47f83d2da"}
May 20 13:20:17.297458  INFO    pushing image   {"req_id": "237b5b1b", "build_id": "52c47f83d2da", "tag": "909427826938.dkr.ecr.eu-west-2.amazonaws.com/testground-eu-west-2-benchmarks:52c47f83d2da"}
```

You can see that both runs results in the same Docker build, but we tag with a unique ID, essentially requiring Kubernetes to pull images, even though are build time we know they are the same.