### PR TITLE
remove BuildID from docker based builders

### DIFF
--- a/pkg/build/docker_generic.go
+++ b/pkg/build/docker_generic.go
@@ -72,6 +72,14 @@ func (b *DockerGenericBuilder) Build(ctx context.Context, in *api.BuildInput, ow
 		ArtifactPath: imageID,
 	}
 
+	// Default tag for the testplan image
+	defaultImageTag := fmt.Sprintf("%s:%s", in.TestPlan, imageID)
+
+	ow.Infow("tagging image", "image_id", imageID, "tag", defaultImageTag)
+	if err = cli.ImageTag(ctx, out.ArtifactPath, defaultImageTag); err != nil {
+		return out, err
+	}
+
 	if cfg.PushRegistry {
 		pushStart := time.Now()
 		defer func() { ow.Infow("image push completed", "took", time.Since(pushStart).Truncate(time.Second)) }()

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -235,6 +235,14 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 		Dependencies: deps,
 	}
 
+	// Default tag for the testplan image
+	defaultImageTag := fmt.Sprintf("%s:%s", in.TestPlan, imageID)
+
+	ow.Infow("tagging image", "image_id", imageID, "tag", defaultImageTag)
+	if err = cli.ImageTag(ctx, out.ArtifactPath, defaultImageTag); err != nil {
+		return out, err
+	}
+
 	if cfg.PushRegistry {
 		pushStart := time.Now()
 		defer func() { ow.Infow("image push completed", "took", time.Since(pushStart).Truncate(time.Second)) }()

--- a/pkg/build/registry.go
+++ b/pkg/build/registry.go
@@ -33,7 +33,7 @@ func pushToAWSRegistry(ctx context.Context, ow *rpc.OutputWriter, client *client
 	}
 
 	// Tag the image under the AWS ECR repository.
-	tag := uri + ":" + in.BuildID
+	tag := uri + ":" + out.ArtifactPath
 	ow.Infow("tagging image", "tag", tag)
 	if err = client.ImageTag(ctx, out.ArtifactPath, tag); err != nil {
 		return err
@@ -62,7 +62,7 @@ func pushToAWSRegistry(ctx context.Context, ow *rpc.OutputWriter, client *client
 func pushToDockerHubRegistry(ctx context.Context, ow *rpc.OutputWriter, client *client.Client, in *api.BuildInput, out *api.BuildOutput) error {
 	uri := in.EnvConfig.DockerHub.Repo + "/testground"
 
-	tag := uri + ":" + in.BuildID
+	tag := uri + ":" + out.ArtifactPath
 	ow.Infow("tagging image", "source", out.ArtifactPath, "repo", uri, "tag", tag)
 
 	if err := client.ImageTag(ctx, out.ArtifactPath, tag); err != nil {


### PR DESCRIPTION
TODO:
- [ ] investigate further if there is a docker API that returns the BuildID - I couldn't find one immediately.
- [x] tag image with `testplan-name:<build id>` prior to pushing (when working with local:docker)
- [ ] decide whether to keep `BuildID` because of `exec:go` builder.