### PR TITLE
deterministic docker image name and tag

### DIFF
--- a/pkg/build/docker_generic.go
+++ b/pkg/build/docker_generic.go
@@ -72,6 +72,14 @@ func (b *DockerGenericBuilder) Build(ctx context.Context, in *api.BuildInput, ow
 		ArtifactPath: imageID,
 	}
 
+	// Default tag for the testplan image
+	defaultImageTag := fmt.Sprintf("%s:%s", in.TestPlan, imageID)
+
+	ow.Infow("tagging image", "image_id", imageID, "tag", defaultImageTag)
+	if err = cli.ImageTag(ctx, out.ArtifactPath, defaultImageTag); err != nil {
+		return out, err
+	}
+
 	if cfg.PushRegistry {
 		pushStart := time.Now()
 		defer func() { ow.Infow("image push completed", "took", time.Since(pushStart).Truncate(time.Second)) }()

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -235,6 +235,14 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 		Dependencies: deps,
 	}
 
+	// Default tag for the testplan image
+	defaultImageTag := fmt.Sprintf("%s:%s", in.TestPlan, imageID)
+
+	ow.Infow("tagging image", "image_id", imageID, "tag", defaultImageTag)
+	if err = cli.ImageTag(ctx, out.ArtifactPath, defaultImageTag); err != nil {
+		return out, err
+	}
+
 	if cfg.PushRegistry {
 		pushStart := time.Now()
 		defer func() { ow.Infow("image push completed", "took", time.Since(pushStart).Truncate(time.Second)) }()

--- a/pkg/build/registry.go
+++ b/pkg/build/registry.go
@@ -33,7 +33,7 @@ func pushToAWSRegistry(ctx context.Context, ow *rpc.OutputWriter, client *client
 	}
 
 	// Tag the image under the AWS ECR repository.
-	tag := uri + ":" + in.BuildID
+	tag := uri + ":" + out.ArtifactPath
 	ow.Infow("tagging image", "tag", tag)
 	if err = client.ImageTag(ctx, out.ArtifactPath, tag); err != nil {
 		return err
@@ -62,7 +62,7 @@ func pushToAWSRegistry(ctx context.Context, ow *rpc.OutputWriter, client *client
 func pushToDockerHubRegistry(ctx context.Context, ow *rpc.OutputWriter, client *client.Client, in *api.BuildInput, out *api.BuildOutput) error {
 	uri := in.EnvConfig.DockerHub.Repo + "/testground"
 
-	tag := uri + ":" + in.BuildID
+	tag := uri + ":" + out.ArtifactPath
 	ow.Infow("tagging image", "source", out.ArtifactPath, "repo", uri, "tag", tag)
 
 	if err := client.ImageTag(ctx, out.ArtifactPath, tag); err != nil {

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -121,5 +121,8 @@ func GetImageID(ctx context.Context, cli *client.Client, defaultTag string) (str
 	}
 
 	// get 3cde7451eb28 from sha256:3cde7451eb28a3199f2c7d4e8e02a98f2e96b9a34dd4a9bc7eeaa5a192a1536f
+	if !strings.HasPrefix(images[0].ID, "sha256:") {
+		panic(fmt.Sprintf("expected image ID to start with 'sha256:', instead got: %s", images[0].ID))
+	}
 	return images[0].ID[7 : 7+12], nil
 }


### PR DESCRIPTION
Currently we are generating a unique build ID, and naming our test plan images with it, which results in unnecessary queries to the Docker Registry when Docker need to create containers from a given image.

This PR is updating the name scheme for our testplan images, so that we reference them with:
`<testplan-name>:<docker image id>`

---

We still need to keep the unique `BuildID` in order to determine the `docker image id` for a given Docker build (i.e. we call `docker image list` and filter based on the unique build id, in order to fetch the `docker image id`.