### PR TITLE
Implement nullop builder

### DIFF
--- a/pkg/build/nullop.go
+++ b/pkg/build/nullop.go
@@ -1,0 +1,35 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"reflect"
+
+	"github.com/testground/testground/pkg/api"
+	"github.com/testground/testground/pkg/rpc"
+)
+
+type NullOpBuilder struct{}
+
+type NullOpBuilderConfig struct {}
+
+func (b *NullOpBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.OutputWriter) (*api.BuildOutput, error) {
+	var (
+		bin  = fmt.Sprintf("exec-nullop--%s", in.TestPlan)
+		path = filepath.Join(in.EnvConfig.Dirs().Work(), bin)
+	)
+
+	return &api.BuildOutput{
+		ArtifactPath: path,
+		Dependencies: make(map[string] string),
+	}, nil
+}
+
+func (*NullOpBuilder) ID() string {
+	return "exec:nullop"
+}
+
+func (*NullOpBuilder) ConfigType() reflect.Type {
+	return reflect.TypeOf(NullOpBuilderConfig{})
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -20,6 +20,7 @@ import (
 // AllBuilders enumerates all builders known to the system.
 var AllBuilders = []api.Builder{
 	&build.DockerGoBuilder{},
+	&build.NullOpBuilder{},
 	&build.ExecGoBuilder{},
 	&build.DockerGenericBuilder{},
 }

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -160,7 +160,7 @@ func (*LocalExecutableRunner) ConfigType() reflect.Type {
 }
 
 func (*LocalExecutableRunner) CompatibleBuilders() []string {
-	return []string{"exec:go"}
+	return []string{"exec:go", "exec:nullop"}
 }
 
 func (*LocalExecutableRunner) TerminateAll(ctx context.Context, ow *rpc.OutputWriter) error {


### PR DESCRIPTION
`exec:nullop`, a builder that returns a pre-built binary.

I'm writing a Haskell SDK for testground, and it's convenient for me to just drop a binary to `$TESTGROUND_HOME/data/work/exec-nullop--$TESTPLAN` rather than either spinning docker up or writing a whole Haskell builder.