### PR TITLE
integration tests for sidecar on local:docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ test-integ-cluster-k8s:
 test-integ-local-docker:
 	./integration_tests/04_docker_placebo_ok.sh
 	./integration_tests/05_docker_placebo_stall.sh
+	./integration_tests/06_docker_network_ping-pong.sh
 test-integ-local-exec:
 	./integration_tests/03_exec_go_placebo_ok.sh
 

--- a/integration_tests/06_docker_network_ping-pong.sh
+++ b/integration_tests/06_docker_network_ping-pong.sh
@@ -19,4 +19,8 @@ SIZEOUT=$(cat ./"$RUNID"/single/0/run.out | wc -c)
 echo "run.out is $SIZEOUT bytes."
 SIZEERR=$(cat ./"$RUNID"/single/0/run.err | wc -c)
 test $SIZEOUT -gt 0 && test $SIZEERR -eq 0
+pushd $RUNID
+OUTCOMEOK=$(find . | grep run.out | xargs awk '{print $0, FILENAME}' | grep "outcome\":\"ok\"" | wc -l)
+test $OUTCOMEOK -eq 2
+popd
 popd

--- a/integration_tests/06_docker_network_ping-pong.sh
+++ b/integration_tests/06_docker_network_ping-pong.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+my_dir="$(dirname "$0")"
+source "$my_dir/header.sh"
+
+testground plan import --from plans/network
+testground build single --builder docker:go --plan network | tee build.out
+export ARTIFACT=$(awk -F\" '/generated build artifact/ {print $8}' build.out)
+docker tag $ARTIFACT testplan:network
+
+pushd $TEMPDIR
+testground healthcheck --runner local:docker --fix
+testground run single --runner local:docker --builder docker:go --use-build testplan:network --instances 2 --plan network --testcase ping-pong --collect | tee run.out
+RUNID=$(awk '/finished run with ID/ { print $9 }' run.out)
+echo "checking run $RUNID"
+file $RUNID.tgz
+unzip $RUNID.tgz
+SIZEOUT=$(cat ./"$RUNID"/single/0/run.out | wc -c)
+echo "run.out is $SIZEOUT bytes."
+SIZEERR=$(cat ./"$RUNID"/single/0/run.err | wc -c)
+test $SIZEOUT -gt 0 && test $SIZEERR -eq 0
+popd


### PR DESCRIPTION
This PR is adding a run for the `network/ping-pong` testplan, which exercises the `sidecar` and confirms we get two outputs with `outcome: ok` from the run.