### PR TITLE
resolve services on each test run

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/hashicorp/golang-lru v0.5.1
 	github.com/imdario/mergo v0.3.8
 	github.com/kubernetes/client-go v11.0.0+incompatible
 	github.com/logrusorgru/aurora v0.0.0-20191017060258-dc85c304c434

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,7 @@ github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:
 github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -216,6 +216,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		// Serialize the runenv into env variables to pass to docker.
 		env := conv.ToOptionsSlice(runenv.ToEnvVars())
 		env = append(env, "INFLUXDB_URL=http://testground-influxdb:8086")
+		env = append(env, "REDIS_HOST=testground-redis")
 
 		// Set the log level if provided in cfg.
 		if cfg.LogLevel != "" {

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -117,6 +117,7 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 
 			env := conv.ToOptionsSlice(runenv.ToEnvVars())
 			env = append(env, "INFLUXDB_URL=http://localhost:8086")
+			env = append(env, "REDIS_HOST=localhost")
 
 			ow.Infow("starting test case instance", "plan", input.TestPlan, "group", g.ID, "number", i, "total", total)
 

--- a/pkg/sidecar/docker_reactor.go
+++ b/pkg/sidecar/docker_reactor.go
@@ -42,7 +42,7 @@ type DockerReactor struct {
 	runidsCache    *lru.Cache
 }
 
-func NewDockerReactor() (*DockerReactor, error) {
+func NewDockerReactor() (Reactor, error) {
 	docker, err := docker.NewManager()
 	if err != nil {
 		return nil, err

--- a/pkg/sidecar/docker_reactor.go
+++ b/pkg/sidecar/docker_reactor.go
@@ -8,10 +8,12 @@ import (
 	"net"
 	"os"
 	"strings"
+	gosync "sync"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/hashicorp/go-multierror"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 
@@ -32,13 +34,49 @@ import (
 var PublicAddr = net.ParseIP("1.1.1.1")
 
 type DockerReactor struct {
+	gosync.Mutex
+
 	client         *sync.Client
 	servicesRoutes []net.IP
 	manager        *docker.Manager
+	runidsCache    *lru.Cache
 }
 
-func NewDockerReactor() (Reactor, error) {
-	// TODO: Generalize this to a list of services.
+func NewDockerReactor() (*DockerReactor, error) {
+	docker, err := docker.NewManager()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := sync.NewGenericClient(context.Background(), logging.S())
+	if err != nil {
+		return nil, err
+	}
+
+	// sidecar nodes perform Redis GC.
+	client.EnableBackgroundGC(nil)
+
+	cache, _ := lru.New(32)
+
+	r := &DockerReactor{
+		client:      client,
+		manager:     docker,
+		runidsCache: cache,
+	}
+
+	r.ResolveServices("constructor")
+
+	return r, nil
+}
+
+func (d *DockerReactor) ResolveServices(runid string) {
+	d.Lock()
+	defer d.Unlock()
+
+	if _, ok := d.runidsCache.Get(runid); ok {
+		return
+	}
+
 	wantedRoutes := []string{
 		os.Getenv(EnvRedisHost),
 		os.Getenv(EnvInfluxdbHost),
@@ -58,24 +96,8 @@ func NewDockerReactor() (Reactor, error) {
 		resolvedRoutes = append(resolvedRoutes, ip.IP)
 	}
 
-	docker, err := docker.NewManager()
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := sync.NewGenericClient(context.Background(), logging.S())
-	if err != nil {
-		return nil, err
-	}
-
-	// sidecar nodes perform Redis GC.
-	client.EnableBackgroundGC(nil)
-
-	return &DockerReactor{
-		client:         client,
-		servicesRoutes: resolvedRoutes,
-		manager:        docker,
-	}, nil
+	d.runidsCache.Add(runid, struct{}{})
+	d.servicesRoutes = resolvedRoutes
 }
 
 func (d *DockerReactor) Handle(globalctx context.Context, handler InstanceHandler) error {
@@ -132,6 +154,9 @@ func (d *DockerReactor) handleContainer(ctx context.Context, container *docker.C
 	}
 
 	logging.S().Debugw("handle container", "name", info.Name, "image", info.Image)
+
+	// Resolve allowed services, so that we update network routes
+	d.ResolveServices(params.TestRun)
 
 	// Remove the TestOutputsPath. We can't store anything from the sidecar.
 	params.TestOutputsPath = ""

--- a/pkg/sidecar/k8s_reactor.go
+++ b/pkg/sidecar/k8s_reactor.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	gosync "sync"
 	"time"
 
 	"github.com/testground/sdk-go/runtime"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/hashicorp/go-multierror"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
@@ -37,12 +39,49 @@ var (
 )
 
 type K8sReactor struct {
+	gosync.Mutex
+
 	client          *sync.Client
 	manager         *docker.Manager
 	allowedServices []AllowedService
+	runidsCache     *lru.Cache
 }
 
-func NewK8sReactor() (Reactor, error) {
+func NewK8sReactor() (*K8sReactor, error) {
+	docker, err := docker.NewManager()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := sync.NewGenericClient(context.Background(), logging.S())
+	if err != nil {
+		return nil, err
+	}
+
+	// sidecar nodes perform Redis GC.
+	client.EnableBackgroundGC(nil)
+
+	cache, _ := lru.New(32)
+
+	r := &K8sReactor{
+		client:      client,
+		manager:     docker,
+		runidsCache: cache,
+	}
+
+	r.ResolveServices("constructor")
+
+	return r, nil
+}
+
+func (d *K8sReactor) ResolveServices(runid string) {
+	d.Lock()
+	defer d.Unlock()
+
+	if _, ok := d.runidsCache.Get(runid); ok {
+		return
+	}
+
 	wantedServices := []struct {
 		name string
 		host string
@@ -70,24 +109,8 @@ func NewK8sReactor() (Reactor, error) {
 		resolvedServices = append(resolvedServices, AllowedService{s.name, ip.IP})
 	}
 
-	docker, err := docker.NewManager()
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := sync.NewGenericClient(context.Background(), logging.S())
-	if err != nil {
-		return nil, err
-	}
-
-	// sidecar nodes perform Redis GC.
-	client.EnableBackgroundGC(nil)
-
-	return &K8sReactor{
-		client:          client,
-		manager:         docker,
-		allowedServices: resolvedServices,
-	}, nil
+	d.runidsCache.Add(runid, struct{}{})
+	d.allowedServices = resolvedServices
 }
 
 func (d *K8sReactor) Handle(ctx context.Context, handler InstanceHandler) error {
@@ -142,6 +165,9 @@ func (d *K8sReactor) manageContainer(ctx context.Context, container *docker.Cont
 	if !ok {
 		return nil, fmt.Errorf("couldn't get pod name from container labels for: %s", container.ID)
 	}
+
+	// Resolve allowed services, so that we update network routes
+	d.ResolveServices(params.TestRun)
 
 	err = waitForPodRunningPhase(ctx, podName)
 	if err != nil {

--- a/pkg/sidecar/k8s_reactor.go
+++ b/pkg/sidecar/k8s_reactor.go
@@ -47,7 +47,7 @@ type K8sReactor struct {
 	runidsCache     *lru.Cache
 }
 
-func NewK8sReactor() (*K8sReactor, error) {
+func NewK8sReactor() (Reactor, error) {
 	docker, err := docker.NewManager()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Addresses: https://github.com/testground/testground/issues/1006

---

This PR is adding an LRU cache to both K8s and Docker reactors to keep track of the `run-ids` that the `sidecar` has seen. The first time the `sidecar` sees a new `run-id`, it tries to resolve the necessary auxiliary services (influxdb, redis, etc.) so that we know which routes to allow when managing the networks for the test run containers.

---

TODO:
- [x] confirm that #1006 works - if influxdb is started after the sidecar, we get measurements in influxdb

FOLLOW UP:
- [x] confirm that the Redis client continue to work if Redis moves to another IP. Redis client ideally should handle re-connects.
- [ ] add a retry mechanism in case our DNS queries fail when seeing a new test run id.