### PR TITLE
terminate go-proxy when testground terminate

### DIFF
--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -558,6 +558,7 @@ func (*LocalDockerRunner) TerminateAll(ctx context.Context, ow *rpc.OutputWriter
 	infraOpts := types.ContainerListOptions{}
 	infraOpts.Filters = filters.NewArgs()
 	infraOpts.Filters.Add("name", "testground-grafana")
+	infraOpts.Filters.Add("name", "testground-goproxy")
 	infraOpts.Filters.Add("name", "testground-influxdb")
 	infraOpts.Filters.Add("name", "testground-redis")
 	infraOpts.Filters.Add("name", "testground-sidecar")

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -184,6 +184,7 @@ func (*LocalExecutableRunner) TerminateAll(ctx context.Context, ow *rpc.OutputWr
 	opts := types.ContainerListOptions{}
 	opts.Filters = filters.NewArgs()
 	opts.Filters.Add("name", "testground-grafana")
+	opts.Filters.Add("name", "testground-goproxy")
 	opts.Filters.Add("name", "testground-redis")
 	opts.Filters.Add("name", "testground-influxdb")
 	opts.Filters.Add("name", "testground-sidecar")


### PR DESCRIPTION
@coryschwartz not sure if `testground-goproxy` was emitted on purpose or not for `testground terminate`, but I think this command should be tearing down all containers and processes that Testground created. WDYT?