### PR TITLE
sidecar: compile only on linux

### DIFF
--- a/pkg/sidecar/mock.go
+++ b/pkg/sidecar/mock.go
@@ -1,3 +1,5 @@
+//+build linux
+
 package sidecar
 
 import (


### PR DESCRIPTION
Looks like with https://github.com/testground/testground/pull/939 we merged code that breaks compilation on MacOS, and we didn't catch this, since our CI only uses Linux.

This PR is fixing the build on MacOS, and I am also working on subsequent PR which will add a `job` on CircleCI, to confirm that unit tests (`go test`) and compilation works on MacOS.