### PR TITLE
sidecar: start http server by default

### DIFF
--- a/.circleci/sidecar.yaml
+++ b/.circleci/sidecar.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: testground-sidecar
+spec:
+  selector:
+    matchLabels:
+      name: testground-sidecar
+  template:
+    metadata:
+      labels:
+        name: testground-sidecar
+    spec:
+      terminationGracePeriodSeconds: 10
+      hostPID: true
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: testground-sidecar
+        image: iptestground/sidecar:edge
+        command: ["testground"]
+        args: ["sidecar", "--runner", "mock"]
+        ports:
+        - name: sidecarhttp
+          containerPort: 6060
+        resources:
+          limits:
+            cpu: 20m
+            memory: 26Mi
+          requests:
+            cpu: 20m
+            memory: 26Mi
+      nodeSelector:
+        testground.node.role.plan: "true"
+

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,5 @@ kind-cluster:
 	kubectl apply -f .circleci/pvc.yaml
 	kubectl label nodes kind-control-plane testground.node.role.plan=true
 	kubectl label nodes kind-control-plane testground.node.role.infra=true
+	kind load docker-image iptestground/sidecar:edge
+	kubectl apply -f .circleci/sidecar.yaml

--- a/env-example.toml
+++ b/env-example.toml
@@ -26,6 +26,7 @@ testplan_pod_cpu            = "100m"
 testplan_pod_memory         = "100Mi"
 collect_outputs_pod_cpu     = "100m"
 collect_outputs_pod_memory  = "100Mi"
+autoscaler_enabled          = false
 provider                    = "aws"
 sysctls = [
   "net.core.somaxconn=10000",

--- a/env-kind.toml
+++ b/env-kind.toml
@@ -1,0 +1,19 @@
+[runners."cluster:k8s"]
+testplan_pod_cpu            = "10m"
+testplan_pod_memory         = "10Mi"
+collect_outputs_pod_cpu     = "10m"
+collect_outputs_pod_memory  = "10Mi"
+autoscaler_enabled          = false
+provider                    = ""
+sysctls = []
+
+[runners."local:docker"]
+ulimits = [
+  "nofile=1048576:1048576",
+]
+
+[daemon]
+listen = ":8080"
+
+[client]
+endpoint = "localhost:8080"

--- a/integration_tests/header.sh
+++ b/integration_tests/header.sh
@@ -15,6 +15,8 @@ function finish {
 trap finish EXIT
 
 TEMPDIR=`mktemp -d`
-testground daemon > daemon.out 2>&1 &
+mkdir -p /home/circleci/testground
+cp env-kind.toml /home/circleci/testground/.env.toml
+testground daemon > $TEMPDIR/daemon.out 2>&1 &
 DAEMONPID=$!
 sleep 2

--- a/pkg/cmd/sidecar.go
+++ b/pkg/cmd/sidecar.go
@@ -32,10 +32,6 @@ var SidecarCommand = cli.Command{
 			Usage:    "runner that will be scheduling tasks that should be managed by this sidecar; supported: 'local:docker', 'cluster:k8s'",
 			Required: true,
 		},
-		&cli.BoolFlag{
-			Name:  "pprof",
-			Usage: "enable pprof service on port 6060",
-		},
 	},
 }
 
@@ -44,12 +40,17 @@ func sidecarCommand(c *cli.Context) error {
 		return ErrNotLinux
 	}
 
-	if c.Bool("pprof") {
-		logging.S().Info("starting pprof")
-		go func() {
-			_ = http.ListenAndServe(":6060", nil)
-		}()
-	}
+	startHTTPServer()
 
 	return sidecar.Run(c.String("runner"))
+}
+
+func startHTTPServer() {
+	logging.S().Info("starting http server")
+	go func() {
+		http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "All good!")
+		})
+		_ = http.ListenAndServe(":6060", nil)
+	}()
 }

--- a/pkg/cmd/sidecar.go
+++ b/pkg/cmd/sidecar.go
@@ -48,9 +48,6 @@ func sidecarCommand(c *cli.Context) error {
 func startHTTPServer() {
 	logging.S().Info("starting http server")
 	go func() {
-		http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, "All good!")
-		})
 		_ = http.ListenAndServe(":6060", nil)
 	}()
 }

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -198,7 +198,7 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 	}
 
 	if !enoughResources {
-		return nil, errors.New("too many test instances requested, resize cluster if you need more capacity")
+		ow.Warnw("too many test instances requested, will have to wait for cluster autoscaler to kick in")
 	}
 
 	jobName := fmt.Sprintf("tg-%s", input.TestPlan)

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -161,8 +161,15 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 		}
 	}
 
-	defaultCPU := resource.MustParse(cfg.TestplanPodCPU)
-	defaultMemory := resource.MustParse(cfg.TestplanPodMemory)
+	defaultCPU, err := resource.ParseQuantity(cfg.TestplanPodCPU)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse default test plan pod CPU request; make sure you have specified `testplan_pod_cpu` in .env.toml; err: %w", err)
+	}
+
+	defaultMemory, err := resource.ParseQuantity(cfg.TestplanPodMemory)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse default test plan pod Memory request; make sure you have specified `testplan_pod_memory` in .env.toml; err: %w", err)
+	}
 
 	template := runtime.RunParams{
 		TestPlan:          input.TestPlan,

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -706,13 +706,6 @@ func (c *ClusterK8sRunner) createTestplanPod(ctx context.Context, podName string
 					Args:            []string{"-c", "until nc -vz $HOST_IP 6060; do echo \"Waiting for local sidecar to listen to $HOST_IP:6060\"; sleep 2; done;"},
 					Command:         []string{"sh"},
 					Env:             env,
-					VolumeMounts: []v1.VolumeMount{
-						{
-							Name:             sharedVolumeName,
-							MountPath:        "/outputs",
-							MountPropagation: &mountPropagationMode,
-						},
-					},
 					Resources: v1.ResourceRequirements{
 						Limits: v1.ResourceList{
 							v1.ResourceMemory: resource.MustParse("10Mi"),

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -121,7 +121,7 @@ func (r *LocalDockerRunner) Healthcheck(ctx context.Context, engine api.Engine, 
 		ContainerConfig: &container.Config{
 			Image:      "iptestground/sidecar:edge",
 			Entrypoint: []string{"testground"},
-			Cmd:        []string{"sidecar", "--runner", "docker", "--pprof"},
+			Cmd:        []string{"sidecar", "--runner", "docker"},
 			Env:        []string{"REDIS_HOST=testground-redis", "INFLUXDB_HOST=testground-influxdb", "GODEBUG=gctrace=1"},
 		},
 		HostConfig: &container.HostConfig{


### PR DESCRIPTION
Addresses: https://github.com/testground/testground/issues/1055 and https://github.com/testground/testground/issues/1056

Also adds autoscaler support behind a feature flag.

Also adds configurable `collect` pod resource requests that were supposed to be addressed in #1008.

---

Ideally we don't want testplan pods to start on a given host before the dependencies have been started, and this is what this PR is about.

---

Related: Autoscaler PR on `testground/infra`: https://github.com/testground/infra/pull/43

---

TODO:
- [x] remove `pprof` flag from `testground/infra` repo when merging this.