### PR TITLE
Feat/task http

### DIFF
--- a/pkg/api/engine.go
+++ b/pkg/api/engine.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/testground/testground/pkg/config"
 	"github.com/testground/testground/pkg/rpc"
+	"github.com/testground/testground/pkg/task"
 )
 
 type Engine interface {
@@ -22,4 +23,5 @@ type Engine interface {
 
 	EnvConfig() config.EnvConfig
 	Context() context.Context
+	TaskStorage() *task.TaskStorage
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -14,6 +14,7 @@ var RootCommands = cli.CommandsByName{
 	&DescribeCommand,
 	&SidecarCommand,
 	&DaemonCommand,
+	&ServiceCommand,
 	&CollectCommand,
 	&TerminateCommand,
 	&HealthcheckCommand,

--- a/pkg/cmd/service.go
+++ b/pkg/cmd/service.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/testground/testground/pkg/config"
+	"github.com/testground/testground/pkg/logging"
+	"github.com/testground/testground/pkg/service"
+
+	"github.com/urfave/cli/v2"
+)
+
+// DaemonCommand is the specification of the `daemon` command.
+var ServiceCommand = cli.Command{
+	Name:   "service",
+	Usage:  "testground submit queue",
+	Action: serviceCommand,
+}
+
+func serviceCommand(c *cli.Context) error {
+	ctx, cancel := context.WithCancel(ProcessContext())
+	defer cancel()
+
+	cfg := &config.EnvConfig{}
+	if err := cfg.Load(); err != nil {
+		return err
+	}
+
+	srv, err := service.New(cfg)
+	if err != nil {
+		return err
+	}
+
+	exiting := make(chan struct{})
+	defer close(exiting)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-exiting:
+			// no need to shutdown in this case.
+			return
+		}
+
+		logging.S().Infow("shutting down rpc server")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := srv.Shutdown(ctx); err != nil {
+			logging.S().Fatalw("failed to shut down rpc server", "err", err)
+		}
+		logging.S().Infow("rpc server stopped")
+	}()
+
+	logging.S().Infow("listen and serve", "addr", srv.Addr())
+	err = srv.Serve()
+	if err == http.ErrServerClosed {
+		err = nil
+	}
+	return err
+}

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -11,16 +11,22 @@ type ConfigMap map[string]interface{}
 type EnvConfig struct {
 	dirs Directories
 
-	AWS       AWSConfig            `toml:"aws"`
-	DockerHub DockerHubConfig      `toml:"dockerhub"`
-	Builders  map[string]ConfigMap `toml:"builders"`
-	Runners   map[string]ConfigMap `toml:"runners"`
-	Daemon    DaemonConfig         `toml:"daemon"`
-	Client    ClientConfig         `toml:"client"`
+	AWS         AWSConfig            `toml:"aws"`
+	DockerHub   DockerHubConfig      `toml:"dockerhub"`
+	Builders    map[string]ConfigMap `toml:"builders"`
+	Runners     map[string]ConfigMap `toml:"runners"`
+	Daemon      DaemonConfig         `toml:"daemon"`
+	Client      ClientConfig         `toml:"client"`
+	TaskStorage TaskStorageConfig    `toml:"taskstorage"`
 }
 
 func (e EnvConfig) Dirs() Directories {
 	return e.dirs
+}
+
+type TaskStorageConfig struct {
+	Path string `toml:"path"`
+	Max  int    `toml:"max"`
 }
 
 type AWSConfig struct {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/testground/testground/pkg/config"
+	"github.com/testground/testground/pkg/engine"
+	"github.com/testground/testground/pkg/logging"
+
+	"github.com/gorilla/mux"
+	"github.com/pborman/uuid"
+)
+
+type Service struct {
+	server *http.Server
+	l      net.Listener
+	doneCh chan struct{}
+}
+
+// New creates a new Daemon and attaches the following handlers:
+// * POST /task: submit a new task
+// * GET /task/<task-id>: return the current state of a task
+func New(cfg *config.EnvConfig) (srv *Service, err error) {
+
+	engine, err := engine.NewServiceEngine(cfg)
+	if err != nil {
+		return nil, err
+	}
+	err = engine.TaskStorage().Open()
+	if err != nil {
+		return nil, err
+	}
+	defer engine.TaskStorage().Close()
+
+	r := mux.NewRouter()
+
+	// Set a unique request ID.
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Header.Set("X-Request-ID", uuid.New()[:8])
+			next.ServeHTTP(w, r)
+		})
+	})
+
+	r.HandleFunc("/task", srv.submitHandler(engine)).Methods("POST")
+	//	r.HandleFunc("/task/{taskid}", srv.taskinfoHandler(engine)).Methods("GET")
+
+	srv.doneCh = make(chan struct{})
+	srv.server = &http.Server{
+		Handler:      r,
+		WriteTimeout: 1200 * time.Second,
+		ReadTimeout:  1200 * time.Second,
+	}
+
+	srv.l, err = net.Listen("tcp", cfg.Daemon.Listen)
+	if err != nil {
+		return nil, err
+	}
+
+	return srv, nil
+}
+
+// Serve starts the server and blocks until the server is closed, either
+// explicitly via Shutdown, or due to a fault condition. It propagates the
+// non-nil err return value from http.Serve.
+func (d *Service) Serve() error {
+	select {
+	case <-d.doneCh:
+		return fmt.Errorf("tried to reuse a stopped server")
+	default:
+	}
+
+	logging.S().Infow("daemon listening", "addr", d.Addr())
+	return d.server.Serve(d.l)
+}
+
+func (d *Service) Addr() string {
+	return d.l.Addr().String()
+}
+
+func (d *Service) Port() int {
+	return d.l.Addr().(*net.TCPAddr).Port
+}
+
+func (d *Service) Shutdown(ctx context.Context) error {
+	defer close(d.doneCh)
+	return d.server.Shutdown(ctx)
+}

--- a/pkg/service/submit.go
+++ b/pkg/service/submit.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mholt/archiver"
+
+	"github.com/testground/testground/pkg/api"
+	"github.com/testground/testground/pkg/logging"
+	"github.com/testground/testground/pkg/rpc"
+	"github.com/testground/testground/pkg/task"
+)
+
+func (d *Service) submitHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ruid := r.Header.Get("X-Request-ID")
+		log := logging.S().With("req_id", ruid)
+
+		log.Infow("handle request", "command", "build")
+		defer log.Infow("request handled", "command", "build")
+
+		tgw := rpc.NewOutputWriter(w, r)
+
+		// Create a packing directory under the workdir.
+		dir := filepath.Join(engine.EnvConfig().Dirs().Work(), "requests", ruid)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			tgw.WriteError("failed to create temp directory to unpack request", "err", err)
+			return
+		}
+
+		_, _, _, err := consumeBuildRequest(r, dir)
+		if err != nil {
+			tgw.WriteError("failed to consume request", "err", err)
+			return
+		}
+
+		task := task.Task{
+			Priority: 0,
+			Created:  time.Now(),
+			ID:       ruid,
+			State:    task.TaskStateScheduled,
+		}
+
+		engine.TaskStorage().Push(&task)
+
+		tgw.Infof("submitted %s.", ruid)
+	}
+}
+
+func consumeBuildRequest(r *http.Request, dir string) (*api.BuildRequest, string, string, error) {
+	var (
+		req *api.BuildRequest
+		p   *multipart.Part
+		err error
+
+		plan string
+		sdk  string
+	)
+
+	if r.Body == nil {
+		return nil, "", "", fmt.Errorf("failed to parse request: nil body")
+	}
+
+	defer r.Body.Close()
+
+	// Validate the incoming multipart request.
+	ct, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, "", "", fmt.Errorf("failed to parse request: %w", err)
+	}
+
+	if !strings.HasPrefix(ct, "multipart/") {
+		ct := r.Header.Get("Content-Type")
+		return nil, "", "", fmt.Errorf("not a multipart request; Content-Type: %s", ct)
+	}
+
+	rd := multipart.NewReader(r.Body, params["boundary"])
+
+	// 1. Read and decode the request payload.
+	if p, err = rd.NextPart(); err != nil {
+		return nil, "", "", fmt.Errorf("unexpected error when reading composition: %w", err)
+	}
+	if err = json.NewDecoder(p).Decode(&req); err != nil {
+		return nil, "", "", fmt.Errorf("failed to json decode request body: %w", err)
+	}
+
+	var (
+		planzip *os.File
+		sdkzip  *os.File
+	)
+
+	// 2a. Read test plan source archive.
+	if planzip, err = os.Create(filepath.Join(dir, "plan.zip")); err != nil {
+		return nil, "", "", fmt.Errorf("failed to create file for test plan: %w", err)
+	}
+	if p, err = rd.NextPart(); err != nil {
+		return nil, "", "", fmt.Errorf("unexpected error when reading test plan: %w", err)
+	}
+	if _, err = io.Copy(planzip, p); err != nil {
+		return nil, "", "", fmt.Errorf("unexpected error when copying test plan: %w", err)
+	}
+
+	// 2b. Inflate the test plan source archive.
+	plan = filepath.Join(dir, "plan")
+	if err := os.Mkdir(plan, 0755); err != nil {
+		return nil, "", "", fmt.Errorf("failed to create directory for test plan: %w", err)
+	}
+	if err := archiver.NewZip().Unarchive(planzip.Name(), plan); err != nil {
+		return nil, "", "", fmt.Errorf("failed to decompress test plan: %w", err)
+	}
+
+	// 3. Read the optional sdk archive.
+	switch p, err = rd.NextPart(); err {
+	case io.EOF:
+		// this is ok; we have no sdk to link.
+	case nil:
+		// 3a. Read sdk source archive.
+		if sdkzip, err = os.Create(filepath.Join(dir, "sdk.zip")); err != nil {
+			return nil, "", "", fmt.Errorf("failed to create file for sdk: %w", err)
+		}
+		if _, err = io.Copy(sdkzip, p); err != nil {
+			return nil, "", "", fmt.Errorf("unexpected error when copying sdk: %w", err)
+		}
+
+		// 3b. Inflate the sdk source archive.
+		sdk = filepath.Join(dir, "sdk")
+		if err := os.Mkdir(sdk, 0755); err != nil {
+			return nil, "", "", fmt.Errorf("failed to create directory for sdk: %w", err)
+		}
+		if err := archiver.NewZip().Unarchive(sdkzip.Name(), sdk); err != nil {
+			return nil, "", "", fmt.Errorf("failed to decompress sdk: %w", err)
+		}
+	default:
+		// an error occurred.
+		return nil, "", "", fmt.Errorf("unexpected error when reading sdk: %w", err)
+	}
+
+	return req, plan, sdk, nil
+}

--- a/pkg/service/submit.go
+++ b/pkg/service/submit.go
@@ -42,15 +42,15 @@ func (d *Service) submitHandler(engine api.Engine) func(w http.ResponseWriter, r
 			tgw.WriteError("failed to consume request", "err", err)
 			return
 		}
-
-		task := task.Task{
+		// make a task
+		tsk := task.Task{
 			Priority: 0,
 			Created:  time.Now(),
 			ID:       ruid,
 			State:    task.TaskStateScheduled,
 		}
 
-		engine.TaskStorage().Push(&task)
+		engine.TaskStorage().Push(&tsk)
 
 		tgw.Infof("submitted %s.", ruid)
 	}

--- a/pkg/service/taskinfo.go
+++ b/pkg/service/taskinfo.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/testground/testground/pkg/api"
+	"github.com/testground/testground/pkg/rpc"
+)
+
+func (d *Service) taskinfoHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+
+		ruid := vars["taskid"]
+
+		tgw := rpc.NewOutputWriter(w, r)
+
+		tsk, err := engine.TaskStorage().Get(ruid)
+		if err != nil {
+			tgw.Warnw("could not find task in storage", "err", err)
+			return
+		}
+		buf, err := json.Marshal(tsk)
+		if err != nil {
+			tgw.Warnw("could not unmarshal task", "err", err)
+			return
+		}
+
+		tgw.Infof(string(buf))
+	}
+}


### PR DESCRIPTION
Building on the storage model in https://github.com/testground/testground/pull/1051 this adds a task model.


Right now this is just the "build" handler with some modifications, but this shows the gist.

The handler takes requests and saves them to disk, then adds the task to the queue to be executed.

Fix: https://github.com/testground/testground/issues/1043 (when complete)