### PR TITLE
change zip to gzip for all runners ; revert run/build ids to length 12

### DIFF
--- a/integration_tests/01_k8s_kind_placebo_ok.sh
+++ b/integration_tests/01_k8s_kind_placebo_ok.sh
@@ -18,6 +18,8 @@ testground run single --runner cluster:k8s --builder docker:go --use-build testp
 RUNID=$(awk '/finished run with ID/ { print $9 }' run.out)
 echo "checking run $RUNID"
 file $RUNID.tgz
+LENGTH=${#RUNID}
+test $LENGTH -eq 12
 tar -xzvvf $RUNID.tgz
 SIZEOUT=$(cat ./"$RUNID"/single/0/run.out | wc -c)
 echo "run.out is $SIZEOUT bytes."

--- a/integration_tests/03_exec_go_placebo_ok.sh
+++ b/integration_tests/03_exec_go_placebo_ok.sh
@@ -9,6 +9,8 @@ testground run single --runner local:exec --builder exec:go --instances 2 --plan
 RUNID=$(awk '/finished run with ID/ { print $9 }' run.out)
 echo "checking run $RUNID"
 file $RUNID.tgz
+LENGTH=${#RUNID}
+test $LENGTH -eq 12
 tar -xzvvf $RUNID.tgz
 SIZEOUT=$(cat ./"$RUNID"/single/0/run.out | wc -c)
 echo "run.out is $SIZEOUT bytes."

--- a/integration_tests/03_exec_go_placebo_ok.sh
+++ b/integration_tests/03_exec_go_placebo_ok.sh
@@ -9,7 +9,7 @@ testground run single --runner local:exec --builder exec:go --instances 2 --plan
 RUNID=$(awk '/finished run with ID/ { print $9 }' run.out)
 echo "checking run $RUNID"
 file $RUNID.tgz
-unzip $RUNID.tgz
+tar -xzvvf $RUNID.tgz
 SIZEOUT=$(cat ./"$RUNID"/single/0/run.out | wc -c)
 echo "run.out is $SIZEOUT bytes."
 SIZEERR=$(cat ./"$RUNID"/single/0/run.err | wc -c)

--- a/integration_tests/04_docker_placebo_ok.sh
+++ b/integration_tests/04_docker_placebo_ok.sh
@@ -14,7 +14,7 @@ testground run single --runner local:docker --builder docker:go --use-build test
 RUNID=$(awk '/finished run with ID/ { print $9 }' run.out)
 echo "checking run $RUNID"
 file $RUNID.tgz
-unzip $RUNID.tgz
+tar -xzvvf $RUNID.tgz
 SIZEOUT=$(cat ./"$RUNID"/single/0/run.out | wc -c)
 echo "run.out is $SIZEOUT bytes."
 SIZEERR=$(cat ./"$RUNID"/single/0/run.err | wc -c)

--- a/integration_tests/04_docker_placebo_ok.sh
+++ b/integration_tests/04_docker_placebo_ok.sh
@@ -14,6 +14,8 @@ testground run single --runner local:docker --builder docker:go --use-build test
 RUNID=$(awk '/finished run with ID/ { print $9 }' run.out)
 echo "checking run $RUNID"
 file $RUNID.tgz
+LENGTH=${#RUNID}
+test $LENGTH -eq 12
 tar -xzvvf $RUNID.tgz
 SIZEOUT=$(cat ./"$RUNID"/single/0/run.out | wc -c)
 echo "run.out is $SIZEOUT bytes."

--- a/integration_tests/06_docker_network_ping-pong.sh
+++ b/integration_tests/06_docker_network_ping-pong.sh
@@ -14,7 +14,7 @@ testground run single --runner local:docker --builder docker:go --use-build test
 RUNID=$(awk '/finished run with ID/ { print $9 }' run.out)
 echo "checking run $RUNID"
 file $RUNID.tgz
-unzip $RUNID.tgz
+tar -xzvvf $RUNID.tgz
 SIZEOUT=$(cat ./"$RUNID"/single/0/run.out | wc -c)
 echo "run.out is $SIZEOUT bytes."
 SIZEERR=$(cat ./"$RUNID"/single/0/run.err | wc -c)

--- a/integration_tests/06_docker_network_ping-pong.sh
+++ b/integration_tests/06_docker_network_ping-pong.sh
@@ -10,8 +10,8 @@ docker tag $ARTIFACT testplan:network
 
 pushd $TEMPDIR
 testground healthcheck --runner local:docker --fix
-testground run single --runner local:docker --builder docker:go --use-build testplan:network --instances 2 --plan network --testcase ping-pong --collect | tee run.out
-RUNID=$(awk '/finished run with ID/ { print $9 }' run.out)
+testground run single --runner local:docker --builder docker:go --use-build testplan:network --instances 2 --plan network --testcase ping-pong --collect | tee stdout.out
+RUNID=$(awk '/finished run with ID/ { print $9 }' stdout.out)
 echo "checking run $RUNID"
 file $RUNID.tgz
 tar -xzvvf $RUNID.tgz

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -229,8 +229,10 @@ func (e *Engine) DoBuild(ctx context.Context, comp *api.Composition, basesrc str
 				return err
 			}
 
+			buildID := id.String()[24:]
+
 			in := &api.BuildInput{
-				BuildID:         id.String(),
+				BuildID:         buildID,
 				EnvConfig:       *e.envcfg,
 				TestPlan:        plan,
 				Selectors:       grp.Build.Selectors,
@@ -310,7 +312,7 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, ow *rpc.Outpu
 	if err != nil {
 		return nil, err
 	}
-	runid := id.String()
+	runid := id.String()[24:]
 
 	// This var compiles all configurations to coalesce.
 	//

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -224,15 +224,8 @@ func (e *Engine) DoBuild(ctx context.Context, comp *api.Composition, basesrc str
 
 			ow.Infow("performing build for groups", "plan", plan, "groups", grpids, "builder", builder)
 
-			id, err := uuid.NewUUID()
-			if err != nil {
-				return err
-			}
-
-			buildID := id.String()[24:]
-
 			in := &api.BuildInput{
-				BuildID:         buildID,
+				BuildID:         uuid.New().String()[24:],
 				EnvConfig:       *e.envcfg,
 				TestPlan:        plan,
 				Selectors:       grp.Build.Selectors,
@@ -308,11 +301,7 @@ func (e *Engine) DoRun(ctx context.Context, comp *api.Composition, ow *rpc.Outpu
 		return nil, fmt.Errorf("runner %s is incompatible with builder %s", runner, builder)
 	}
 
-	id, err := uuid.NewUUID()
-	if err != nil {
-		return nil, err
-	}
-	runid := id.String()[24:]
+	runid := uuid.New().String()[24:]
 
 	// This var compiles all configurations to coalesce.
 	//

--- a/pkg/runner/common.go
+++ b/pkg/runner/common.go
@@ -76,15 +76,15 @@ func gzipRunOutputs(ctx context.Context, basedir string, input *api.CollectionIn
 			return err
 		}
 
-		relFilePath := file
-		if filepath.IsAbs(dir) {
-			relFilePath, err = filepath.Rel(dir, file)
-			if err != nil {
-				return err
-			}
-		}
+		//relFilePath := file
+		//if filepath.IsAbs(dir) {
+		//relFilePath, err = filepath.Rel(dir, file)
+		//if err != nil {
+		//return err
+		//}
+		//}
 
-		hdr.Name = relFilePath
+		hdr.Name = file
 
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err

--- a/pkg/runner/common.go
+++ b/pkg/runner/common.go
@@ -76,15 +76,15 @@ func gzipRunOutputs(ctx context.Context, basedir string, input *api.CollectionIn
 			return err
 		}
 
-		//relFilePath := file
-		//if filepath.IsAbs(dir) {
-		//relFilePath, err = filepath.Rel(dir, file)
-		//if err != nil {
-		//return err
-		//}
-		//}
+		relFilePath := file
+		if filepath.IsAbs(dir) {
+			relFilePath, err = filepath.Rel(dir, file)
+			if err != nil {
+				return err
+			}
+		}
 
-		hdr.Name = file
+		hdr.Name = input.RunID + "/" + relFilePath
 
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -509,7 +509,7 @@ func (r *LocalDockerRunner) CollectOutputs(ctx context.Context, input *api.Colle
 	dir := r.outputsDir
 	r.lk.RUnlock()
 
-	return zipRunOutputs(ctx, dir, input, ow)
+	return gzipRunOutputs(ctx, dir, input, ow)
 }
 
 // attachContainerToNetwork attaches the provided container to the specified

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -149,7 +149,7 @@ func (r *LocalExecutableRunner) CollectOutputs(ctx context.Context, input *api.C
 	dir := r.outputsDir
 	r.lk.RUnlock()
 
-	return zipRunOutputs(ctx, dir, input, ow)
+	return gzipRunOutputs(ctx, dir, input, ow)
 }
 
 func (*LocalExecutableRunner) ID() string {


### PR DESCRIPTION
This PR is:
1. Reverting `RunID` and `BuildID` to length 12, as there is a limit to image names and tags we can push to a Docker registry.
2. Updating the `collect outputs` functionality for `local:docker` and `local:exec` to return a gzip archive, and be consistent with `cluster:k8s`
4. Adding tests to make sure we stick to length 12 for RunIDs.

@coryschwartz is there a reason for the change in the UUID for the build and the run IDs?

---

Fixes https://github.com/testground/testground/issues/1065
Fixes https://github.com/testground/testground/issues/1068