### PR TITLE
cli: fix misleading default value.

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -59,10 +59,11 @@ var RunCommand = cli.Command{
 					Usage:   "destination for the assets if --collect is set",
 				},
 				&cli.UintFlag{
-					Name:     "instances",
-					Aliases:  []string{"i"},
-					Usage:    "number of instances of the test case to run",
-					Required: true,
+					Name:        "instances",
+					Aliases:     []string{"i"},
+					Usage:       "number of instances of the test case to run",
+					Required:    true,
+					DefaultText: "none",
 				},
 				&cli.StringFlag{
 					Name:     "runner",


### PR DESCRIPTION
Fixes https://github.com/testground/testground/issues/1070.

Unfortunately urfave CLI does not allow you to omit the default value indication, so we have to resort to this hack.