### PR TITLE
docker:go: add option to skip runtime image.

### DIFF
--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -407,7 +407,7 @@ COPY . /
 
 RUN cd ${PLAN_DIR} \
     && go env -w GOPROXY="${GO_PROXY}" \
-    && GOOS=linux GOARCH=amd64 go build -o testplan ${BUILD_TAGS} ${TESTPLAN_EXEC_PKG}
+    && GOOS=linux GOARCH=amd64 go build -o /testplan ${BUILD_TAGS} ${TESTPLAN_EXEC_PKG}
 
 {{.DockerfileExtensions.PostBuild}}
 
@@ -425,12 +425,12 @@ FROM ${RUNTIME_IMAGE} AS binary
 {{.DockerfileExtensions.PreRuntimeCopy}}
 
 COPY --from=builder /testground_dep_list /
-COPY --from=builder /plan/testplan /
+COPY --from=builder /testplan /
 
 {{.DockerfileExtensions.PostRuntimeCopy}}
 
+{{ end }}
+
 EXPOSE 6060
 ENTRYPOINT [ "/testplan"]
-
-{{ end }}
 `

--- a/plans/dockercustomize/manifest.toml
+++ b/plans/dockercustomize/manifest.toml
@@ -7,6 +7,7 @@ runner = "local:docker"
 [builders."docker:go"]
 enabled = true
 runtime_image = "debian"
+# skip_runtime_image = true
 
 [builders."docker:go".dockerfile_extensions]
 pre_mod_download    = "RUN echo 'at pre_mod_download'"


### PR DESCRIPTION
For builds that do more than just compiling go code (e.g. generating things, linking to dynamic libs, etc.), we might want to just use the build container as our runtime container. This is suboptimal, but it's a good way to bootstrap a test plan for a complex target, like Lotus/Filecoin.