### PR TITLE
docker:go: rolling go build caches; make builders `Terminatable`; add basic termination logic to `docker:go`

### DIFF
--- a/pkg/api/engine.go
+++ b/pkg/api/engine.go
@@ -7,6 +7,13 @@ import (
 	"github.com/testground/testground/pkg/rpc"
 )
 
+type ComponentType string
+
+const (
+	RunnerType  = ComponentType("runner")
+	BuilderType = ComponentType("builder")
+)
+
 type Engine interface {
 	BuilderByName(name string) (Builder, bool)
 	RunnerByName(name string) (Runner, bool)
@@ -17,7 +24,7 @@ type Engine interface {
 	DoBuild(context.Context, *Composition, string, string, string, *rpc.OutputWriter) ([]*BuildOutput, error)
 	DoRun(context.Context, *Composition, *rpc.OutputWriter) (*RunOutput, error)
 	DoCollectOutputs(ctx context.Context, runner string, runID string, ow *rpc.OutputWriter) error
-	DoTerminate(ctx context.Context, runner string, ow *rpc.OutputWriter) error
+	DoTerminate(ctx context.Context, ctype ComponentType, ref string, ow *rpc.OutputWriter) error
 	DoHealthcheck(ctx context.Context, runner string, fix bool, ow *rpc.OutputWriter) (*HealthcheckReport, error)
 
 	EnvConfig() config.EnvConfig

--- a/pkg/api/rpc.go
+++ b/pkg/api/rpc.go
@@ -29,7 +29,8 @@ type OutputsRequest struct {
 }
 
 type TerminateRequest struct {
-	Runner string `json:"runner"`
+	Runner  string `json:"runner"`
+	Builder string `json:"builder"`
 }
 
 type HealthcheckRequest struct {

--- a/pkg/build/docker_generic.go
+++ b/pkg/build/docker_generic.go
@@ -60,7 +60,7 @@ func (b *DockerGenericBuilder) Build(ctx context.Context, in *api.BuildInput, ow
 
 	buildStart := time.Now()
 
-	err = docker.BuildImage(ctx, ow, cli, &imageOpts)
+	_, err = docker.BuildImage(ctx, ow, cli, &imageOpts)
 	if err != nil {
 		return nil, fmt.Errorf("docker build failed: %w", err)
 	}

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -563,6 +563,7 @@ RUN cd ${PLAN_DIR} \
 
 {{ if not .SkipRuntimeImage }}
 
+## The 'AS runtime' token is used to parse Docker stdout to extract the build image ID to cache.
 FROM ${RUNTIME_IMAGE} AS runtime
 
 # PLAN_DIR is the location containing the plan source inside the build container.
@@ -577,6 +578,7 @@ COPY --from=builder ${PLAN_DIR}/testplan.bin /testplan
 
 {{ else }}
 
+## The 'AS runtime' token is used to parse Docker stdout to extract the build image ID to cache. 
 FROM builder AS runtime
 
 # PLAN_DIR is the location containing the plan source inside the build container.

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -579,6 +579,11 @@ COPY --from=builder ${PLAN_DIR}/testplan.bin /testplan
 
 FROM builder AS runtime
 
+# PLAN_DIR is the location containing the plan source inside the build container.
+ENV PLAN_DIR /plan
+
+RUN mv ${PLAN_DIR}/testplan.bin /testplan
+
 {{ end }}
 
 EXPOSE 6060

--- a/pkg/daemon/terminate.go
+++ b/pkg/daemon/terminate.go
@@ -26,7 +26,24 @@ func (d *Daemon) terminateHandler(engine api.Engine) func(w http.ResponseWriter,
 			return
 		}
 
-		err = engine.DoTerminate(r.Context(), req.Runner, tgw)
+		var (
+			ctype api.ComponentType
+			ref   string
+		)
+
+		switch {
+		case req.Builder != "" && req.Runner != "":
+			tgw.WriteError("cannot terminate a runner and a builder at the same time")
+			return
+		case req.Builder != "":
+			ctype = api.BuilderType
+			ref = req.Builder
+		case req.Runner != "":
+			ctype = api.RunnerType
+			ref = req.Runner
+		}
+
+		err = engine.DoTerminate(r.Context(), ctype, ref, tgw)
 		if err != nil {
 			tgw.WriteError("terminate error", "err", err.Error())
 			return

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -119,7 +119,7 @@ func EnsureContainerStarted(ctx context.Context, ow *rpc.OutputWriter, cli *clie
 		if err != nil {
 			return nil, false, err
 		}
-		if err := PipeOutput(out, ow.StdoutWriter()); err != nil {
+		if _, err := PipeOutput(out, ow.StdoutWriter()); err != nil {
 			return nil, false, err
 		}
 

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -77,7 +77,7 @@ func TestBuildImageBuildsImages(t *testing.T) {
 		Name:     rndname,
 		BuildCtx: dir,
 	}
-	err := docker.BuildImage(ctx, ow, cli, &opts)
+	_, err := docker.BuildImage(ctx, ow, cli, &opts)
 	require.NoError(t, err)
 
 	// Check that it exists.

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/testground/testground/pkg/api"
 	"github.com/testground/testground/pkg/conv"
+	"github.com/testground/testground/pkg/docker"
 	"github.com/testground/testground/pkg/healthcheck"
 	"github.com/testground/testground/pkg/rpc"
 
@@ -200,7 +201,7 @@ func (*LocalExecutableRunner) TerminateAll(ctx context.Context, ow *rpc.OutputWr
 		containers = append(containers, container.ID)
 	}
 
-	err = deleteContainers(cli, ow, containers)
+	err = docker.DeleteContainers(cli, ow, containers)
 	if err != nil {
 		return fmt.Errorf("failed to list testground containers: %w", err)
 	}

--- a/pkg/runner/registry.go
+++ b/pkg/runner/registry.go
@@ -32,7 +32,7 @@ func (c *ClusterK8sRunner) pushToDockerRegistry(ctx context.Context, ow *rpc.Out
 			return err
 		}
 
-		if err := docker.PipeOutput(rc, ow.StdoutWriter()); err != nil {
+		if _, err := docker.PipeOutput(rc, ow.StdoutWriter()); err != nil {
 			return err
 		}
 

--- a/plans/dockercustomize/manifest.toml
+++ b/plans/dockercustomize/manifest.toml
@@ -1,4 +1,4 @@
-name = "verify"
+name = "dockercustomize"
 
 [defaults]
 builder = "docker:go"
@@ -8,6 +8,7 @@ runner = "local:docker"
 enabled = true
 runtime_image = "debian"
 # skip_runtime_image = true
+# disable_go_build_cache = true
 
 [builders."docker:go".dockerfile_extensions]
 pre_mod_download    = "RUN echo 'at pre_mod_download'"

--- a/plans/dockercustomize/manifest.toml
+++ b/plans/dockercustomize/manifest.toml
@@ -7,8 +7,8 @@ runner = "local:docker"
 [builders."docker:go"]
 enabled = true
 runtime_image = "debian"
+enable_go_build_cache = true
 # skip_runtime_image = true
-# disable_go_build_cache = true
 
 [builders."docker:go".dockerfile_extensions]
 pre_mod_download    = "RUN echo 'at pre_mod_download'"


### PR DESCRIPTION
This commit introduces rolling/carry-over go build caches as a default behaviour in docker:go. Build caches images are maintained per test plan + go version tuple. Every time a build is started, we check if we have an image from a previous build, and if so, reuse it (clearing /plan, /sdk, /testground_dep_list first).

If a prior build cache image doesn't exist, we start with a blank go container.

The goal is to carry over the entire /go directory, which contains the pkg cache. We also set GOCACHE to /go/cache, in order to carry over the build object cache.

This behaviour can be disabled by setting the `disable_go_build_cache=true` option in the builder configuration.

The tradeoffs are as follows of using the rolling cache are as follows:

 * good: the rolling cache leads to super-fast go builds, as dependency sources and their respective build objects are cached across builds of the test plan. For example, if you import the same version of IPFS/Lotus/libp2p every time, you will no longer compile from their sources, but the go build will use the cached intermediate object files. This is akin to running a go build locally.

 * bad: the go toolchain records last access timestamps on every build in the filesystem (https://github.com/golang/go/blob/master/src/cmd/go/internal/cache/cache.go) which effectively invalidates Docker layer caching across builds. So even if you built exactly the same plan source, no Docker layer caches would be hit, because of the timestamps sliding. However, in practice, you will be iterating on the test plan source, and under that assumption, we have found that the end-to-end build is faster.