### PR TITLE
add the ability to ship extra local sources in builds.

### DIFF
--- a/pkg/api/builder.go
+++ b/pkg/api/builder.go
@@ -34,18 +34,9 @@ type BuildInput struct {
 	// TestPlan is the name of the test plan being built.
 	TestPlan string
 
-	// BaseSrcPath is the directory containing the plan under ./plan, and an
-	// optional sdk under ./sdk.
-	BaseSrcPath string
-
-	// TestPlanSrcPath is the directory where the test plan's source has been
-	// placed (i.e. BaseSrcPath/plan).
-	TestPlanSrcPath string
-
-	// SDKSrcPath is the directory where the SDK's source has been placed. It
-	// will be a zero-value if no SDK replacement has been requested, or
-	// BaseSrcPath/sdk otherwise.
-	SDKSrcPath string
+	// UnpackedSources encapsulates the directories where sources for this
+	// build job have been unpacked.
+	UnpackedSources *UnpackedSources
 
 	// Selectors specifies any source selection strings to be sent to the
 	// builder. In the case of go builders, this field maps to build tags.

--- a/pkg/api/engine.go
+++ b/pkg/api/engine.go
@@ -14,6 +14,26 @@ const (
 	BuilderType = ComponentType("builder")
 )
 
+// UnpackedSources represents the set of directories where a build job unpacks
+// its sources.
+type UnpackedSources struct {
+	// BaseDir is the directory containing the plan under ./plan, and an
+	// optional sdk under ./sdk.
+	BaseDir string
+
+	// PlanDir is the directory where the test plan's source has been
+	// placed (i.e. BaseSrcPath/plan).
+	PlanDir string
+
+	// SDKDir is the directory where the SDK's source has been placed. It
+	// will be a zero-value if no SDK replacement has been requested, or
+	// BaseSrcPath/sdk otherwise.
+	SDKDir string
+
+	// ExtraDir is the directory where any extra sources have been unpacked.
+	ExtraDir string
+}
+
 type Engine interface {
 	BuilderByName(name string) (Builder, bool)
 	RunnerByName(name string) (Runner, bool)
@@ -21,7 +41,7 @@ type Engine interface {
 	ListBuilders() map[string]Builder
 	ListRunners() map[string]Runner
 
-	DoBuild(context.Context, *Composition, string, string, string, *rpc.OutputWriter) ([]*BuildOutput, error)
+	DoBuild(context.Context, *Composition, *UnpackedSources, *rpc.OutputWriter) ([]*BuildOutput, error)
 	DoRun(context.Context, *Composition, *rpc.OutputWriter) (*RunOutput, error)
 	DoCollectOutputs(ctx context.Context, runner string, runID string, ow *rpc.OutputWriter) error
 	DoTerminate(ctx context.Context, ctype ComponentType, ref string, ow *rpc.OutputWriter) error

--- a/pkg/api/manifest.go
+++ b/pkg/api/manifest.go
@@ -16,6 +16,13 @@ type TestPlanManifest struct {
 	Builders  map[string]config.ConfigMap `toml:"builders"`
 	Runners   map[string]config.ConfigMap `toml:"runners"`
 	TestCases []*TestCase                 `toml:"testcases"`
+
+	// ExtraSources allows the user to ship extra source directories to the
+	// daemon so they can be considered in the build (e.g. assets, package
+	// overrides, etc.), when certain builders are used.
+	//
+	// It's a mapping of builder => directories.
+	ExtraSources map[string][]string `toml:"extra_sources"`
 }
 
 // TestCase represents a configuration for a test case known by the system.

--- a/pkg/build/docker_generic.go
+++ b/pkg/build/docker_generic.go
@@ -36,7 +36,7 @@ func (b *DockerGenericBuilder) Build(ctx context.Context, in *api.BuildInput, ow
 	cliopts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
 
 	var (
-		basesrc  = in.BaseSrcPath
+		basesrc  = in.UnpackedSources.BaseDir
 		cli, err = client.NewClientWithOpts(cliopts...)
 	)
 	if err != nil {

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -132,9 +132,9 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 	cliopts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
 
 	var (
-		basesrc = in.BaseSrcPath
-		plansrc = in.TestPlanSrcPath
-		sdksrc  = in.SDKSrcPath
+		basesrc = in.UnpackedSources.BaseDir
+		plansrc = in.UnpackedSources.PlanDir
+		sdksrc  = in.UnpackedSources.SDKDir
 
 		cli, err = client.NewClientWithOpts(cliopts...)
 	)

--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -37,8 +37,8 @@ func (b *ExecGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.O
 
 	var (
 		id      = in.BuildID
-		plansrc = in.TestPlanSrcPath
-		sdksrc  = in.SDKSrcPath
+		plansrc = in.UnpackedSources.PlanDir
+		sdksrc  = in.UnpackedSources.SDKDir
 
 		bin  = fmt.Sprintf("exec-go--%s-%s", in.TestPlan, id)
 		path = filepath.Join(in.EnvConfig.Dirs().Work(), bin)

--- a/pkg/build/selector_test.go
+++ b/pkg/build/selector_test.go
@@ -68,7 +68,12 @@ func TestBuildSelector(t *testing.T) {
 				},
 			}
 
-			_, err = engine.DoBuild(context.TODO(), comp, basedir, plandir, "", rpc.Discard())
+			unpacked := &api.UnpackedSources{
+				BaseDir: basedir,
+				PlanDir: plandir,
+			}
+
+			_, err = engine.DoBuild(context.TODO(), comp, unpacked, rpc.Discard())
 			assertion(err)
 		}
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -81,7 +81,7 @@ func (c *Client) Build(ctx context.Context, r *api.BuildRequest, plandir string,
 	// writeZippedDirs a list of directories, zips them into a single zip file, and writes it on w.
 	// if toplevel=true, it will retain the toplevel directories, so if /abc, /def are passed, the resulting
 	// zip archive will contain /abc and /def.
-	// if toplevel=false, it will omit tihe toplevel directories and will place the contents of each
+	// if toplevel=false, it will omit the toplevel directories and will place the contents of each
 	// at the root of the zip, with overwrite=true. So /abc and /def are placed as /abc/* and /def/* at the root.
 	writeZippedDirs := func(w io.Writer, toplevel bool, dirs ...string) error {
 		// A temporary .zip file to deflate the directory into.

--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -166,17 +166,15 @@ func doBuild(c *cli.Context, comp *api.Composition) ([]api.BuildOutput, error) {
 	// if there are extra sources to include for this builder, contextualize
 	// them to the plan's dir.
 	builder := comp.Global.Builder
-	extra, ok := manifest.ExtraSources[builder]
-	if ok && len(extra) != 0 {
-		for i, dir := range extra {
-			if !filepath.IsAbs(dir) {
-				// follow any symlinks in the plan dir.
-				evalPlanDir, err := filepath.EvalSymlinks(planDir)
-				if err != nil {
-					return nil, fmt.Errorf("failed to follow symlinks in plan dir: %w", err)
-				}
-				extra[i] = filepath.Clean(filepath.Join(evalPlanDir, dir))
+	extra := manifest.ExtraSources[builder]
+	for i, dir := range extra {
+		if !filepath.IsAbs(dir) {
+			// follow any symlinks in the plan dir.
+			evalPlanDir, err := filepath.EvalSymlinks(planDir)
+			if err != nil {
+				return nil, fmt.Errorf("failed to follow symlinks in plan dir: %w", err)
 			}
+			extra[i] = filepath.Clean(filepath.Join(evalPlanDir, dir))
 		}
 	}
 

--- a/pkg/daemon/build.go
+++ b/pkg/daemon/build.go
@@ -35,13 +35,13 @@ func (d *Daemon) buildHandler(engine api.Engine) func(w http.ResponseWriter, r *
 			return
 		}
 
-		req, plan, sdk, err := consumeBuildRequest(r, dir)
+		req, unpacked, err := consumeBuildRequest(r, dir)
 		if err != nil {
 			tgw.WriteError("failed to consume request", "err", err)
 			return
 		}
 
-		out, err := engine.DoBuild(r.Context(), &req.Composition, dir, plan, sdk, tgw)
+		out, err := engine.DoBuild(r.Context(), &req.Composition, unpacked, tgw)
 		if err != nil {
 			tgw.WriteError(fmt.Sprintf("engine build error: %s", err))
 			return
@@ -51,18 +51,15 @@ func (d *Daemon) buildHandler(engine api.Engine) func(w http.ResponseWriter, r *
 	}
 }
 
-func consumeBuildRequest(r *http.Request, dir string) (*api.BuildRequest, string, string, error) {
+func consumeBuildRequest(r *http.Request, dir string) (*api.BuildRequest, *api.UnpackedSources, error) {
 	var (
 		req *api.BuildRequest
 		p   *multipart.Part
 		err error
-
-		plan string
-		sdk  string
 	)
 
 	if r.Body == nil {
-		return nil, "", "", fmt.Errorf("failed to parse request: nil body")
+		return nil, nil, fmt.Errorf("failed to parse request: nil body")
 	}
 
 	defer r.Body.Close()
@@ -70,74 +67,96 @@ func consumeBuildRequest(r *http.Request, dir string) (*api.BuildRequest, string
 	// Validate the incoming multipart request.
 	ct, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	if err != nil {
-		return nil, "", "", fmt.Errorf("failed to parse request: %w", err)
+		return nil, nil, fmt.Errorf("failed to parse request: %w", err)
 	}
 
 	if !strings.HasPrefix(ct, "multipart/") {
 		ct := r.Header.Get("Content-Type")
-		return nil, "", "", fmt.Errorf("not a multipart request; Content-Type: %s", ct)
+		return nil, nil, fmt.Errorf("not a multipart request; Content-Type: %s", ct)
 	}
 
 	rd := multipart.NewReader(r.Body, params["boundary"])
 
 	// 1. Read and decode the request payload.
 	if p, err = rd.NextPart(); err != nil {
-		return nil, "", "", fmt.Errorf("unexpected error when reading composition: %w", err)
+		return nil, nil, fmt.Errorf("unexpected error when reading composition: %w", err)
 	}
 	if err = json.NewDecoder(p).Decode(&req); err != nil {
-		return nil, "", "", fmt.Errorf("failed to json decode request body: %w", err)
+		return nil, nil, fmt.Errorf("failed to json decode request body: %w", err)
 	}
 
-	var (
-		planzip *os.File
-		sdkzip  *os.File
-	)
+	unpacked := new(api.UnpackedSources)
+	unpacked.BaseDir = dir
+
+	var planzip *os.File
 
 	// 2a. Read test plan source archive.
 	if planzip, err = os.Create(filepath.Join(dir, "plan.zip")); err != nil {
-		return nil, "", "", fmt.Errorf("failed to create file for test plan: %w", err)
+		return nil, nil, fmt.Errorf("failed to create file for test plan: %w", err)
 	}
 	if p, err = rd.NextPart(); err != nil {
-		return nil, "", "", fmt.Errorf("unexpected error when reading test plan: %w", err)
+		return nil, nil, fmt.Errorf("unexpected error when reading test plan: %w", err)
 	}
 	if _, err = io.Copy(planzip, p); err != nil {
-		return nil, "", "", fmt.Errorf("unexpected error when copying test plan: %w", err)
+		return nil, nil, fmt.Errorf("unexpected error when copying test plan: %w", err)
 	}
 
 	// 2b. Inflate the test plan source archive.
-	plan = filepath.Join(dir, "plan")
-	if err := os.Mkdir(plan, 0755); err != nil {
-		return nil, "", "", fmt.Errorf("failed to create directory for test plan: %w", err)
+	unpacked.PlanDir = filepath.Join(dir, "plan")
+	if err := os.Mkdir(unpacked.PlanDir, 0755); err != nil {
+		return nil, nil, fmt.Errorf("failed to create directory for test plan: %w", err)
 	}
-	if err := archiver.NewZip().Unarchive(planzip.Name(), plan); err != nil {
-		return nil, "", "", fmt.Errorf("failed to decompress test plan: %w", err)
-	}
-
-	// 3. Read the optional sdk archive.
-	switch p, err = rd.NextPart(); err {
-	case io.EOF:
-		// this is ok; we have no sdk to link.
-	case nil:
-		// 3a. Read sdk source archive.
-		if sdkzip, err = os.Create(filepath.Join(dir, "sdk.zip")); err != nil {
-			return nil, "", "", fmt.Errorf("failed to create file for sdk: %w", err)
-		}
-		if _, err = io.Copy(sdkzip, p); err != nil {
-			return nil, "", "", fmt.Errorf("unexpected error when copying sdk: %w", err)
-		}
-
-		// 3b. Inflate the sdk source archive.
-		sdk = filepath.Join(dir, "sdk")
-		if err := os.Mkdir(sdk, 0755); err != nil {
-			return nil, "", "", fmt.Errorf("failed to create directory for sdk: %w", err)
-		}
-		if err := archiver.NewZip().Unarchive(sdkzip.Name(), sdk); err != nil {
-			return nil, "", "", fmt.Errorf("failed to decompress sdk: %w", err)
-		}
-	default:
-		// an error occurred.
-		return nil, "", "", fmt.Errorf("unexpected error when reading sdk: %w", err)
+	if err := archiver.NewZip().Unarchive(planzip.Name(), unpacked.PlanDir); err != nil {
+		return nil, nil, fmt.Errorf("failed to decompress test plan: %w", err)
 	}
 
-	return req, plan, sdk, nil
+	// Read optional parts (sdk and extra)
+Outer:
+	for {
+		switch p, err = rd.NextPart(); err {
+		case io.EOF:
+			// we're done.
+			break Outer
+		case nil:
+			var (
+				filename = p.FileName() // can be sdk.zip or extra.zip
+				kind     = strings.TrimSuffix(filename, ".zip")
+			)
+
+			fmt.Println(filename, kind)
+
+			// Read the archive.
+			targetzip, err := os.Create(filepath.Join(dir, filename))
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to create file for %s: %w", kind, err)
+			}
+			if _, err = io.Copy(targetzip, p); err != nil {
+				return nil, nil, fmt.Errorf("unexpected error when copying %s: %w", kind, err)
+			}
+
+			// Inflate the archive.
+			destdir := filepath.Join(dir, kind)
+			if err := os.Mkdir(destdir, 0755); err != nil {
+				return nil, nil, fmt.Errorf("failed to create directory for sdk: %w", err)
+			}
+			if err := archiver.NewZip().Unarchive(targetzip.Name(), destdir); err != nil {
+				return nil, nil, fmt.Errorf("failed to decompress sdk: %w", err)
+			}
+
+			// Set the right directory.
+			switch kind {
+			case "sdk":
+				unpacked.SDKDir = destdir
+			case "extra":
+				unpacked.ExtraDir = destdir
+			}
+
+		default:
+			// an error occurred.
+			return nil, nil, fmt.Errorf("unexpected error when reading optional parts: %w", err)
+		}
+
+	}
+
+	return req, unpacked, nil
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -131,7 +131,7 @@ func (e *Engine) ListRunners() map[string]api.Runner {
 	return m
 }
 
-func (e *Engine) DoBuild(ctx context.Context, comp *api.Composition, basesrc string, plansrc string, sdksrc string, ow *rpc.OutputWriter) ([]*api.BuildOutput, error) {
+func (e *Engine) DoBuild(ctx context.Context, comp *api.Composition, sources *api.UnpackedSources, ow *rpc.OutputWriter) ([]*api.BuildOutput, error) {
 	if err := comp.ValidateForBuild(); err != nil {
 		return nil, fmt.Errorf("invalid composition: %w", err)
 	}
@@ -231,9 +231,7 @@ func (e *Engine) DoBuild(ctx context.Context, comp *api.Composition, basesrc str
 				Selectors:       grp.Build.Selectors,
 				Dependencies:    grp.Build.Dependencies.AsMap(),
 				BuildConfig:     obj,
-				BaseSrcPath:     basesrc,
-				TestPlanSrcPath: plansrc,
-				SDKSrcPath:      sdksrc,
+				UnpackedSources: sources,
 			}
 
 			res, err := bm.Build(ctx, in, ow)


### PR DESCRIPTION
This allows us to create isomorphism in complex builds, such as when test plans depend on external artifacts.

It also allows us to ship assets external to the test plan source.

Additionally, it unlocks the ability to override dependencies (e.g. via replace directives) replacing them with local copies. With the go builders, users no longer need to push changes in their upstream repos to get them picked up in their test plans.

## How is this done?

1. Manifests can now specify an `extra_sources` map, consisting of `builder => []paths`, which specify which paths to include as extras for which builders (conditional activation).
2. The paths are resolved relative to the plan source directory (where the manifest resides), evaluating symlinks first. This makes use that if the plan under `$TESTGROUND_HOME/plans/planA` is a symlink, we pick up the extras from the symlinked location.
3. Extras are packed into a zip file, and are sent in the multipart request.
4. Builders are free to use these extras.