### PR TITLE
compositions: trickle default configs to all groups.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/go-git/go-git/v5 v5.0.0
-	github.com/go-playground/validator/v10 v10.1.0
+	github.com/go-playground/validator/v10 v10.3.0
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8c
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
-github.com/go-playground/validator/v10 v10.1.0 h1:LNfPbVcg93V/91tkAQH8nbFbFn7u2X4hHnLMeRZHIMM=
-github.com/go-playground/validator/v10 v10.1.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
+github.com/go-playground/validator/v10 v10.3.0 h1:nZU+7q+yJoFmwvNgv/LnPUkwPal62+b2xXj0AU1Es7o=
+github.com/go-playground/validator/v10 v10.3.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-redis/redis/v7 v7.2.0 h1:CrCexy/jYWZjW0AyVoHlcJUeZN19VWlbepTh1Vq6dJs=
 github.com/go-redis/redis/v7 v7.2.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=

--- a/pkg/api/composition_test.go
+++ b/pkg/api/composition_test.go
@@ -8,6 +8,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateGroupsUnique(t *testing.T) {
+	c := &Composition{
+		Metadata: Metadata{},
+		Global: Global{
+			Plan:    "foo_plan",
+			Case:    "foo_case",
+			Builder: "docker:go",
+			Runner:  "local:docker",
+		},
+		Groups: []*Group{
+			{ID: "repeated"},
+			{ID: "repeated"},
+		},
+	}
+
+	require.Error(t, c.ValidateForBuild())
+	require.Error(t, c.ValidateForRun())
+}
+
 func TestDefaultTestParamsApplied(t *testing.T) {
 	c := &Composition{
 		Metadata: Metadata{},

--- a/pkg/api/composition_test.go
+++ b/pkg/api/composition_test.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/testground/testground/pkg/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultTestParamsApplied(t *testing.T) {
+	c := &Composition{
+		Metadata: Metadata{},
+		Global: Global{
+			Plan:           "foo_plan",
+			Case:           "foo_case",
+			TotalInstances: 3,
+			Builder:        "docker:go",
+			Runner:         "local:docker",
+			Run: &Run{
+				TestParams: map[string]string{
+					"param1": "value1:default:composition",
+					"param2": "value2:default:composition",
+					"param3": "value3:default:composition",
+				},
+			},
+		},
+		Groups: []*Group{
+			{
+				ID:        "all_set",
+				Instances: Instances{Count: 1},
+				Run: Run{
+					TestParams: map[string]string{
+						"param1": "value1:set",
+						"param2": "value2:set",
+						"param3": "value3:set",
+					},
+				},
+			},
+			{
+				ID:        "none_set",
+				Instances: Instances{Count: 1},
+			},
+			{
+				ID:        "first_set",
+				Instances: Instances{Count: 1},
+				Run: Run{
+					TestParams: map[string]string{
+						"param1": "value1:set",
+					},
+				},
+			},
+		},
+	}
+
+	manifest := &TestPlanManifest{
+		Name: "foo_plan",
+		Builders: map[string]config.ConfigMap{
+			"docker:go": {},
+		},
+		Runners: map[string]config.ConfigMap{
+			"local:docker": {},
+		},
+		TestCases: []*TestCase{
+			{
+				Name:      "foo_case",
+				Instances: InstanceConstraints{Minimum: 1, Maximum: 100},
+				Parameters: map[string]Parameter{
+					"param4": {
+						Type:    "string",
+						Default: "value4:default:manifest",
+					},
+				},
+			},
+		},
+	}
+
+	ret, err := c.PrepareForRun(manifest)
+	require.NoError(t, err)
+	require.NotNil(t, ret)
+
+	// group all_set.
+	require.EqualValues(t, "value1:set", ret.Groups[0].Run.TestParams["param1"])
+	require.EqualValues(t, "value2:set", ret.Groups[0].Run.TestParams["param2"])
+	require.EqualValues(t, "value3:set", ret.Groups[0].Run.TestParams["param3"])
+	require.EqualValues(t, "value4:default:manifest", ret.Groups[0].Run.TestParams["param4"])
+
+	// group none_set.
+	require.EqualValues(t, "value1:default:composition", ret.Groups[1].Run.TestParams["param1"])
+	require.EqualValues(t, "value2:default:composition", ret.Groups[1].Run.TestParams["param2"])
+	require.EqualValues(t, "value3:default:composition", ret.Groups[1].Run.TestParams["param3"])
+	require.EqualValues(t, "value4:default:manifest", ret.Groups[1].Run.TestParams["param4"])
+
+	// group first_set
+	require.EqualValues(t, "value1:set", ret.Groups[2].Run.TestParams["param1"])
+	require.EqualValues(t, "value2:default:composition", ret.Groups[2].Run.TestParams["param2"])
+	require.EqualValues(t, "value3:default:composition", ret.Groups[2].Run.TestParams["param3"])
+	require.EqualValues(t, "value4:default:manifest", ret.Groups[2].Run.TestParams["param4"])
+}
+
+func TestDefaultBuildParamsApplied(t *testing.T) {
+	c := &Composition{
+		Metadata: Metadata{},
+		Global: Global{
+			Plan:           "foo_plan",
+			Case:           "foo_case",
+			TotalInstances: 3,
+			Builder:        "docker:go",
+			Runner:         "local:docker",
+			Build: &Build{
+				Selectors: []string{"default_selector_1", "default_selector_2"},
+				Dependencies: []Dependency{
+					{"dependency:a", "1.0.0.default"},
+					{"dependency:b", "2.0.0.default"},
+				},
+			},
+		},
+		Groups: []*Group{
+			{
+				ID: "no_local_settings",
+			},
+			{
+				ID: "dep_override",
+				Build: Build{
+					Dependencies: []Dependency{
+						{"dependency:a", "1.0.0.overridden"},
+						{"dependency:c", "1.0.0.locally_set"},
+					},
+				},
+			},
+			{
+				ID: "selector_and_dep_override",
+				Build: Build{
+					Selectors: []string{"overridden"},
+					Dependencies: []Dependency{
+						{"dependency:a", "1.0.0.overridden"},
+						{"dependency:c", "1.0.0.locally_set"},
+					},
+				},
+			},
+		},
+	}
+
+	manifest := &TestPlanManifest{
+		Name: "foo_plan",
+		Builders: map[string]config.ConfigMap{
+			"docker:go": {},
+		},
+		Runners: map[string]config.ConfigMap{
+			"local:docker": {},
+		},
+		TestCases: []*TestCase{
+			{
+				Name:      "foo_case",
+				Instances: InstanceConstraints{Minimum: 1, Maximum: 100},
+			},
+		},
+	}
+
+	ret, err := c.PrepareForBuild(manifest)
+	require.NoError(t, err)
+	require.NotNil(t, ret)
+
+	// group no_local_settings.
+	require.EqualValues(t, []string{"default_selector_1", "default_selector_2"}, ret.Groups[0].Build.Selectors)
+	require.ElementsMatch(t, Dependencies{{"dependency:a", "1.0.0.default"}, {"dependency:b", "2.0.0.default"}}, ret.Groups[0].Build.Dependencies)
+
+	// group dep_override.
+	require.EqualValues(t, []string{"default_selector_1", "default_selector_2"}, ret.Groups[1].Build.Selectors)
+	require.ElementsMatch(t, Dependencies{
+		{"dependency:a", "1.0.0.overridden"},
+		{"dependency:b", "2.0.0.default"},
+		{"dependency:c", "1.0.0.locally_set"},
+	}, ret.Groups[1].Build.Dependencies)
+
+	// group selector_and_dep_override
+	require.EqualValues(t, []string{"overridden"}, ret.Groups[2].Build.Selectors)
+	require.ElementsMatch(t, Dependencies{
+		{"dependency:a", "1.0.0.overridden"},
+		{"dependency:b", "2.0.0.default"},
+		{"dependency:c", "1.0.0.locally_set"},
+	}, ret.Groups[2].Build.Dependencies)
+}

--- a/pkg/build/selector_test.go
+++ b/pkg/build/selector_test.go
@@ -59,7 +59,7 @@ func TestBuildSelector(t *testing.T) {
 						"go_proxy_mode": "direct",
 					},
 				},
-				Groups: []api.Group{
+				Groups: []*api.Group{
 					{
 						ID:        "test",
 						Build:     api.Build{Selectors: selectors},

--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -177,7 +177,7 @@ func doBuild(c *cli.Context, comp *api.Composition) ([]api.BuildOutput, error) {
 	}
 
 	for i, out := range res {
-		g := &comp.Groups[i]
+		g := comp.Groups[i]
 		logging.S().Infow("generated build artifact", "group", g.ID, "artifact", out.ArtifactPath)
 		g.Run.Artifact = out.ArtifactPath
 	}

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -60,7 +60,7 @@ func createSingletonComposition(c *cli.Context) (*api.Composition, error) {
 			Runner:         runner,
 			TotalInstances: instances,
 		},
-		Groups: []api.Group{
+		Groups: []*api.Group{
 			{
 				ID: "single",
 				Instances: api.Instances{

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -166,7 +166,7 @@ func doRun(c *cli.Context, comp *api.Composition) (err error) {
 
 		// Populate the returned build IDs.
 		for i, groupIdx := range buildIdx {
-			g := &comp.Groups[groupIdx]
+			g := comp.Groups[groupIdx]
 			g.Run.Artifact = bout[i].ArtifactPath
 		}
 


### PR DESCRIPTION
Compositions can now specify `[build]` and `[run]` subtables in the `[global]` table.

Build and run settings in groups will inherit the default configuration. The coalescing will happen in this manner:

* `build.dependencies` => the default dependency set will be merged into the local one, with the local entries taking precedence.
* `build.selectors` => no merging; the local selector list will override the default selector list entirely.
* `run.artifact` => local artifacts take precedence over default.
  * (known issue: if a global artifact is set, there's no way to "unset" it for a group, so that a build is triggered.)
* `run.test_params` => the default test parameters will be merged into the local map, with the local entries taking precedence.

---

Fixes #521.
Closes #648 (fix included here).