### PR TITLE
inject port numbers as env variables.

### DIFF
--- a/pkg/runner/common_ports.go
+++ b/pkg/runner/common_ports.go
@@ -1,0 +1,21 @@
+package runner
+
+import (
+	"strings"
+)
+
+// ExposedPorts is a simple type that holds port mappings.
+type ExposedPorts map[string]string
+
+// ToEnvVars returns a map that represents these port mappings as environment
+// variables, in the form ${LABEL}_PORT=${PORT_NUMBER}.
+//
+// The result can be piped through conv.ToOptionsSlice to turn it into a slice.
+func (e ExposedPorts) ToEnvVars() map[string]string {
+	ret := make(map[string]string, len(e))
+	for label, port := range e {
+		k := strings.ToUpper(strings.TrimSpace(label)) + "_PORT"
+		ret[k] = port
+	}
+	return ret
+}

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -63,7 +63,7 @@ type LocalDockerRunnerConfig struct {
 	// (default: ["nofile=1048576:1048576"]).
 	Ulimits []string `toml:"ulimits"`
 
-	ExposedPorts []string `toml:"exposed_ports"`
+	ExposedPorts ExposedPorts `toml:"exposed_ports"`
 }
 
 // defaultConfig is the default configuration. Incoming configurations will be
@@ -73,7 +73,7 @@ var defaultConfig = LocalDockerRunnerConfig{
 	Unstarted:      false,
 	Background:     false,
 	Ulimits:        []string{"nofile=1048576:1048576"},
-	ExposedPorts:   []string{"6060"},
+	ExposedPorts:   map[string]string{"pprof": "6060"},
 }
 
 // LocalDockerRunner is a runner that manually stands up as many docker
@@ -224,6 +224,9 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		env := conv.ToOptionsSlice(runenv.ToEnvVars())
 		env = append(env, "INFLUXDB_URL=http://testground-influxdb:8086")
 		env = append(env, "REDIS_HOST=testground-redis")
+
+		// Inject exposed ports.
+		env = append(env, conv.ToOptionsSlice(cfg.ExposedPorts.ToEnvVars())...)
 
 		// Set the log level if provided in cfg.
 		if cfg.LogLevel != "" {


### PR DESCRIPTION
This facilitates isomorphism across runners, because test workloads can now rely on port numbers being set via environment variables, instead of hard-coded values in source.

- port numbers are now specified as a map `label => port`, _à la Docker compose_.
- `local:docker` and `cluster:k8s` support port mappings and thus inject the port numbers as env variables with the name `${LABEL}_PORT`.
- `local:exec` will not inject anything because it doesn't support this feature (TODO/UX: print a warning in the runner informing that port mappings are not applied?).
- https://github.com/testground/sdk-go/pull/24 allows us to load such port numbers, and specify fallbacks if they're not set (e.g. `0` -- random).

---

Fixes https://github.com/testground/testground/issues/1094.