### PR TITLE
feat: `docker:go` cross-repo dependency replacement

### DIFF
--- a/pkg/api/builder.go
+++ b/pkg/api/builder.go
@@ -51,11 +51,11 @@ type BuildInput struct {
 	// builder. In the case of go builders, this field maps to build tags.
 	Selectors []string
 
-	// Dependencies are the versions of upstream dependencies we want to build
-	// against. For a go build, this could be e.g.:
+	// Dependencies are the versions and target of upstream dependencies we wants
+	// to build against. For a go build, this could be e.g.:
 	//  github.com/ipfs/go-ipfs=v0.4.22
-	//  github.com/libp2p/go-libp2p=v0.2.8
-	Dependencies map[string]string
+	//  github.com/libp2p/go-libp2p=github.com/user/fork@v0.2.8
+	Dependencies map[string]DependencyTarget
 
 	// BuildConfig is the configuration of the build job sourced from the test
 	// plan manifest, coalesced with any user-provided overrides.
@@ -75,4 +75,14 @@ type BuildOutput struct {
 	// containing the collapsed transitive upstream dependency set of this
 	// build.
 	Dependencies map[string]string
+}
+
+// DependencyTarget encapsulates the target and version of a dependency.
+type DependencyTarget struct {
+	// Target is the replacement dependency we want to use. It can be a different
+	// fork or some module if the builder supports it.
+	Target string
+
+	// Version is the version of the dependency we want to use.
+	Version string
 }

--- a/pkg/api/composition.go
+++ b/pkg/api/composition.go
@@ -208,6 +208,9 @@ type Dependency struct {
 	// Module is the module name/path for the import to be overridden.
 	Module string `toml:"module" json:"module" validate:"required"`
 
+	// Target is the override module.
+	Target string `toml:"target" json:"target" validate:"target"`
+
 	// Version is the override version.
 	Version string `toml:"version" json:"version" validate:"required"`
 }

--- a/pkg/api/composition_test.go
+++ b/pkg/api/composition_test.go
@@ -129,8 +129,8 @@ func TestDefaultBuildParamsApplied(t *testing.T) {
 			Build: &Build{
 				Selectors: []string{"default_selector_1", "default_selector_2"},
 				Dependencies: []Dependency{
-					{"dependency:a", "1.0.0.default"},
-					{"dependency:b", "2.0.0.default"},
+					{"dependency:a", "", "1.0.0.default"},
+					{"dependency:b", "", "2.0.0.default"},
 				},
 			},
 		},
@@ -142,8 +142,9 @@ func TestDefaultBuildParamsApplied(t *testing.T) {
 				ID: "dep_override",
 				Build: Build{
 					Dependencies: []Dependency{
-						{"dependency:a", "1.0.0.overridden"},
-						{"dependency:c", "1.0.0.locally_set"},
+						{"dependency:a", "", "1.0.0.overridden"},
+						{"dependency:c", "", "1.0.0.locally_set"},
+						{"dependency:d", "remote/fork", "1.0.0.locally_set"},
 					},
 				},
 			},
@@ -152,8 +153,8 @@ func TestDefaultBuildParamsApplied(t *testing.T) {
 				Build: Build{
 					Selectors: []string{"overridden"},
 					Dependencies: []Dependency{
-						{"dependency:a", "1.0.0.overridden"},
-						{"dependency:c", "1.0.0.locally_set"},
+						{"dependency:a", "", "1.0.0.overridden"},
+						{"dependency:c", "", "1.0.0.locally_set"},
 					},
 				},
 			},
@@ -182,21 +183,22 @@ func TestDefaultBuildParamsApplied(t *testing.T) {
 
 	// group no_local_settings.
 	require.EqualValues(t, []string{"default_selector_1", "default_selector_2"}, ret.Groups[0].Build.Selectors)
-	require.ElementsMatch(t, Dependencies{{"dependency:a", "1.0.0.default"}, {"dependency:b", "2.0.0.default"}}, ret.Groups[0].Build.Dependencies)
+	require.ElementsMatch(t, Dependencies{{"dependency:a", "", "1.0.0.default"}, {"dependency:b", "", "2.0.0.default"}}, ret.Groups[0].Build.Dependencies)
 
 	// group dep_override.
 	require.EqualValues(t, []string{"default_selector_1", "default_selector_2"}, ret.Groups[1].Build.Selectors)
 	require.ElementsMatch(t, Dependencies{
-		{"dependency:a", "1.0.0.overridden"},
-		{"dependency:b", "2.0.0.default"},
-		{"dependency:c", "1.0.0.locally_set"},
+		{"dependency:a", "", "1.0.0.overridden"},
+		{"dependency:b", "", "2.0.0.default"},
+		{"dependency:c", "", "1.0.0.locally_set"},
+		{"dependency:d", "remote/fork", "1.0.0.locally_set"},
 	}, ret.Groups[1].Build.Dependencies)
 
 	// group selector_and_dep_override
 	require.EqualValues(t, []string{"overridden"}, ret.Groups[2].Build.Selectors)
 	require.ElementsMatch(t, Dependencies{
-		{"dependency:a", "1.0.0.overridden"},
-		{"dependency:b", "2.0.0.default"},
-		{"dependency:c", "1.0.0.locally_set"},
+		{"dependency:a", "", "1.0.0.overridden"},
+		{"dependency:b", "", "2.0.0.default"},
+		{"dependency:c", "", "1.0.0.locally_set"},
 	}, ret.Groups[2].Build.Dependencies)
 }

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -198,7 +198,10 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 	// If we have version overrides, apply them.
 	var replaces []string
 	for mod, ver := range in.Dependencies {
-		replaces = append(replaces, fmt.Sprintf("-replace=%s=%s@%s", mod, mod, ver))
+		if ver.Target == "" {
+			ver.Target = mod
+		}
+		replaces = append(replaces, fmt.Sprintf("-replace=%s=%s@%s", mod, ver.Target, ver.Version))
 	}
 
 	// Inject replace directives for the SDK modules.

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -100,11 +100,18 @@ func createSingletonComposition(c *cli.Context) (*api.Composition, error) {
 	}
 	comp.Groups[0].Build.Dependencies = make([]api.Dependency, 0, len(dependencies))
 
-	for name, ver := range deps {
+	for name, target := range deps {
+		parts := strings.Split(target, "@")
+		if (len(parts)) != 2 {
+			return nil, fmt.Errorf("invalid target-version: %s", target)
+		}
+
 		dep := api.Dependency{
 			Module:  name,
-			Version: ver,
+			Target:  parts[0],
+			Version: parts[1],
 		}
+
 		comp.Groups[0].Build.Dependencies = append(comp.Groups[0].Build.Dependencies, dep)
 	}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -224,12 +224,21 @@ func (e *Engine) DoBuild(ctx context.Context, comp *api.Composition, basesrc str
 
 			ow.Infow("performing build for groups", "plan", plan, "groups", grpids, "builder", builder)
 
+			deps := make(map[string]api.DependencyTarget, len(grp.Build.Dependencies))
+
+			for _, dep := range grp.Build.Dependencies {
+				deps[dep.Module] = api.DependencyTarget{
+					Target:  dep.Target,
+					Version: dep.Version,
+				}
+			}
+
 			in := &api.BuildInput{
 				BuildID:         uuid.New().String()[24:],
 				EnvConfig:       *e.envcfg,
 				TestPlan:        plan,
 				Selectors:       grp.Build.Selectors,
-				Dependencies:    grp.Build.Dependencies.AsMap(),
+				Dependencies:    deps,
 				BuildConfig:     obj,
 				BaseSrcPath:     basesrc,
 				TestPlanSrcPath: plansrc,


### PR DESCRIPTION
This PR should close #48 by allowing cross-repository replacement directives for dependencies on the `docker:go` builder. I followed @raulk instructions on [this comment](https://github.com/testground/testground/issues/48#issuecomment-536328534). Some thoughts:

> 1. Adopt go.mod notation in the CLI `--dep` parameter: `<dependency>=[<target>]@<version>`. When `target` is missing, we assume no remapping of repos.

Done.

The current iteration is forcing the `@` to be present just like the specification. Should it be optional when we only have a version?

>2. Adjust the components mentioned above. The `build.Input.Dependencies` field turn into a `map[string]DependencyTarget`, where `DependencyTarget` is a struct containing the target and version.

Done.

>3. In the future, to preserve correctness, builders not supporting this feature (e.g. a hypothetical `docker:js` builder that relies on `npm install` and `package.json`) will need to return an error if DependencyTarget.Target is not empty.

Wouldn't it be better to just parse whatever is after the `=` signal on each builder, allowing for a different syntax per builder, according to the target languate?