### PR TITLE
exec:go: build with no optimisations nor inlining.

### DIFF
--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -86,7 +86,7 @@ func (b *ExecGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.O
 
 	// Calculate the arguments to go build.
 	// go build -o <output_path> [-tags <comma-separated tags>] <exec_pkg>
-	var args = []string{"build", "-o", "-gcflags='all=-N -l'", path}
+	var args = []string{"build", "-gcflags='all=-N -l'", "-o", path}
 	if len(in.Selectors) > 0 {
 		args = append(args, "-tags")
 		args = append(args, strings.Join(in.Selectors, ","))

--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -86,7 +86,7 @@ func (b *ExecGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.O
 
 	// Calculate the arguments to go build.
 	// go build -o <output_path> [-tags <comma-separated tags>] <exec_pkg>
-	var args = []string{"build", "-o", path}
+	var args = []string{"build", "-o", "-gcflags='all=-N -l'", path}
 	if len(in.Selectors) > 0 {
 		args = append(args, "-tags")
 		args = append(args, strings.Join(in.Selectors, ","))


### PR DESCRIPTION
This enables step-through debugging when attaching a debugger.
Otherwise, breakpoints and step-through won't line up with source.
Recommended by https://blog.jetbrains.com/go/2019/02/debugging-with-goland-getting-started/

---

Obviously this has an impact on test plan performance, and therefore any metrics that are captured. We might want to turn it into a flag, but it's also worth noting that `local:exec` is meant for quick iteration and debugging, rather than actual reproducible runs (as there is no isolation).