### PR TITLE
informative instance tags in pretty log printer.

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -124,6 +124,7 @@ func runSingleCmd(c *cli.Context) (err error) {
 	if comp, err = createSingletonComposition(c); err != nil {
 		return err
 	}
+	logging.S().Infof("created a synthetic composition file for this job; all instances will run under singleton group %q", comp.Groups[0].ID)
 	return doRun(c, comp)
 }
 

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -100,12 +100,12 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 
 		for i := 0; i < g.Instances; i++ {
 			total++
-			id := fmt.Sprintf("instance %3d", total)
+			tag := fmt.Sprintf("%s[%03d]", g.ID, i)
 
 			odir := filepath.Join(r.outputsDir, input.TestPlan, input.RunID, g.ID, strconv.Itoa(i))
 			if err := os.MkdirAll(odir, 0777); err != nil {
 				err = fmt.Errorf("failed to create outputs dir %s: %w", odir, err)
-				pretty.FailStart(id, err)
+				pretty.FailStart(tag, err)
 				continue
 			}
 
@@ -128,13 +128,14 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 			cmd.Env = env
 
 			if err := cmd.Start(); err != nil {
-				pretty.FailStart(id, err)
+				pretty.FailStart(tag, err)
 				continue
 			}
 
 			commands = append(commands, cmd)
 
-			pretty.Manage(id, stdout, stderr)
+			// instance tag in output: << group[zero_padded_i] >>, e.g. << miner[003] >>
+			pretty.Manage(tag, stdout, stderr)
 		}
 	}
 


### PR DESCRIPTION
* In `local:exec`, we now identify instances in the pretty log output with: `<< group_id[idx] >>`
* In `local:docker`, we use the tag: `<< group_id[idx] (container_id[:6])`.

Since it's not obvious that composition-less runs via CLI are mapped to a singleton group named `single`, I've added a log statement for UX purposes.

This is what it looks like on `local:exec`:

![image](https://user-images.githubusercontent.com/1101242/87777383-47a9ae80-c821-11ea-967a-7e632d403429.png)

---

Fixes https://github.com/filecoin-project/oni/issues/152.

---

cc @schomatis.