### PR TITLE
fix: add ulimit memlock=-1

### DIFF
--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/testground/testground/pkg/api"
+	"github.com/testground/testground/pkg/conv"
 	"github.com/testground/testground/pkg/docker"
 	"github.com/testground/testground/pkg/rpc"
 
@@ -246,12 +247,17 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 		args["BUILD_TAGS"] = &s
 	}
 
+	// Updates the ulimit option to allow go 1.14 to build on all kernels.
+	// Ref: https://github.com/docker-library/golang/issues/320
+	ulimits, _ := conv.ToUlimits([]string{"memlock=-1"})
+
 	// Make sure we are attached to the testground-build network
 	// so the builder can make use of the goproxy container.
 	opts := types.ImageBuildOptions{
 		Tags:        []string{in.BuildID},
 		BuildArgs:   args,
 		NetworkMode: "host",
+		Ulimits:     ulimits,
 	}
 
 	// If a docker network was created for the proxy, link it to the build container

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -257,6 +257,8 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 				}},
 			}
 
+			// Updates the ulimit option to allow go 1.14 to build on all kernels.
+			// Ref: https://github.com/docker-library/golang/issues/320
 			if !strings.Contains(strings.Join(cfg.Ulimits, " "), "memlock=-1") {
 				cfg.Ulimits = append(cfg.Ulimits, "memlock=-1")
 			}

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -257,13 +257,15 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 				}},
 			}
 
-			if len(cfg.Ulimits) > 0 {
-				ulimits, err := conv.ToUlimits(cfg.Ulimits)
-				if err == nil {
-					hcfg.Resources = container.Resources{Ulimits: ulimits}
-				} else {
-					ow.Warnf("invalid ulimit will be ignored %v", err)
-				}
+			if !strings.Contains(strings.Join(cfg.Ulimits, " "), "memlock=-1") {
+				cfg.Ulimits = append(cfg.Ulimits, "memlock=-1")
+			}
+
+			ulimits, err := conv.ToUlimits(cfg.Ulimits)
+			if err == nil {
+				hcfg.Resources = container.Resources{Ulimits: ulimits}
+			} else {
+				ow.Warnf("invalid ulimit will be ignored %v", err)
 			}
 
 			// Create the container.


### PR DESCRIPTION
This closes #701 by adding `memlock=-1` to all ulimits across all `local:docker` runs and `docker:go` builds thus allowing go 1.14 to build on all kernels.

1. I added it in all runs and it **cannot** be overridden by flags. If you think it's best, I can update it to be the default, i.e., if the ulimit option is empty.
2. Should we add to `docker:generic` builds too in case people want to use Go?

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>