### PR TITLE
feat: detect redis port collision on local:exec

### DIFF
--- a/integration_tests/01_k8s_kind_placebo_ok.sh
+++ b/integration_tests/01_k8s_kind_placebo_ok.sh
@@ -26,3 +26,6 @@ echo "run.out is $SIZEOUT bytes."
 SIZEERR=$(cat ./"$RUNID"/single/0/run.err | wc -c)
 test $SIZEOUT -gt 0 && test $SIZEERR -eq 0
 popd
+
+echo "terminating remaining containers"
+testground terminate --builder docker:go

--- a/integration_tests/02_k8s_kind_placebo_stall.sh
+++ b/integration_tests/02_k8s_kind_placebo_stall.sh
@@ -20,3 +20,6 @@ testground terminate --runner=cluster:k8s
 sleep 10
 AFTER=$(kubectl get pods | grep placebo | grep Running | wc -l)
 test $BEFORE -gt $AFTER
+
+echo "terminating remaining containers"
+testground terminate --builder docker:go

--- a/integration_tests/03_exec_go_placebo_ok.sh
+++ b/integration_tests/03_exec_go_placebo_ok.sh
@@ -17,3 +17,6 @@ echo "run.out is $SIZEOUT bytes."
 SIZEERR=$(cat ./"$RUNID"/single/0/run.err | wc -c)
 test $SIZEOUT -gt 0 && test $SIZEERR -eq 0
 popd
+
+echo "terminating remaining containers"
+testground terminate --runner local:exec

--- a/integration_tests/04_docker_placebo_ok.sh
+++ b/integration_tests/04_docker_placebo_ok.sh
@@ -22,3 +22,7 @@ echo "run.out is $SIZEOUT bytes."
 SIZEERR=$(cat ./"$RUNID"/single/0/run.err | wc -c)
 test $SIZEOUT -gt 0 && test $SIZEERR -eq 0
 popd
+
+echo "terminating remaining containers"
+testground terminate --runner local:docker
+testground terminate --builder docker:go

--- a/integration_tests/05_docker_placebo_stall.sh
+++ b/integration_tests/05_docker_placebo_stall.sh
@@ -16,3 +16,7 @@ testground terminate --runner=local:docker
 sleep 10 
 AFTER=$(docker ps | grep placebo | wc -l)
 test $BEFORE -gt $AFTER
+
+echo "terminating remaining containers"
+testground terminate --runner local:docker
+testground terminate --builder docker:go

--- a/integration_tests/06_docker_network_ping-pong.sh
+++ b/integration_tests/06_docker_network_ping-pong.sh
@@ -24,3 +24,7 @@ OUTCOMEOK=$(find . | grep run.out | xargs awk '{print $0, FILENAME}' | grep "out
 test $OUTCOMEOK -eq 2
 popd
 popd
+
+echo "terminating remaining containers"
+testground terminate --runner local:docker
+testground terminate --builder docker:go

--- a/pkg/cmd/itest/build_test.go
+++ b/pkg/cmd/itest/build_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestBuildExecGo(t *testing.T) {
-	err := runSingle(t,
+	err := runSingle(t, nil,
 		"build",
 		"single",
 		"--builder",
@@ -24,6 +24,9 @@ func TestBuildDockerGo(t *testing.T) {
 	// pick the .env.toml file this way, in case the user has defined a custom
 	// docker endpoint. I don't think those assumptions stand.
 	err := runSingle(t,
+		&terminateOpts{
+			builder: "docker:go",
+		},
 		"build",
 		"single",
 		"--builder",

--- a/pkg/cmd/itest/common_test.go
+++ b/pkg/cmd/itest/common_test.go
@@ -11,7 +11,12 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func runSingle(t *testing.T, args ...string) error {
+type terminateOpts struct {
+	runner  string
+	builder string
+}
+
+func runSingle(t *testing.T, opts *terminateOpts, args ...string) error {
 	t.Helper()
 
 	cfg := &config.EnvConfig{}
@@ -34,5 +39,19 @@ func runSingle(t *testing.T, args ...string) error {
 	app.HideVersion = true
 
 	args = append([]string{"testground", "--endpoint", srv.Addr()}, args...)
-	return app.Run(args)
+	err = app.Run(args)
+
+	if opts != nil {
+		if opts.builder != "" {
+			args = []string{"testground", "--endpoint", srv.Addr(), "terminate", "--builder", opts.builder}
+			_ = app.Run(args)
+		}
+
+		if opts.runner != "" {
+			args = []string{"testground", "--endpoint", srv.Addr(), "terminate", "--runner", opts.runner}
+			_ = app.Run(args)
+		}
+	}
+
+	return err
 }

--- a/pkg/cmd/itest/describe_test.go
+++ b/pkg/cmd/itest/describe_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestDescribeExistingPlan(t *testing.T) {
-	err := runSingle(t,
+	err := runSingle(t, nil,
 		"describe",
 		"--plan",
 		"placebo",
@@ -17,7 +17,7 @@ func TestDescribeExistingPlan(t *testing.T) {
 }
 
 func TestDescribeInexistentPlan(t *testing.T) {
-	err := runSingle(t,
+	err := runSingle(t, nil,
 		"describe",
 		"--plan",
 		"i-do-not-exist",

--- a/pkg/cmd/itest/list_test.go
+++ b/pkg/cmd/itest/list_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestList(t *testing.T) {
-	err := runSingle(t,
+	err := runSingle(t, nil,
 		"plan",
 		"list",
 	)

--- a/pkg/cmd/itest/run_test.go
+++ b/pkg/cmd/itest/run_test.go
@@ -6,6 +6,10 @@ import (
 
 func TestAbortedTestShouldFailLocal(t *testing.T) {
 	err := runSingle(t,
+		&terminateOpts{
+			runner:  "local:exec",
+			builder: "exec:go",
+		},
 		"run",
 		"single",
 		"--builder",
@@ -27,6 +31,10 @@ func TestAbortedTestShouldFailLocal(t *testing.T) {
 
 func TestAbortedTestShouldFailDocker(t *testing.T) {
 	err := runSingle(t,
+		&terminateOpts{
+			runner:  "local:docker",
+			builder: "docker:go",
+		},
 		"run",
 		"single",
 		"--builder",
@@ -45,6 +53,10 @@ func TestAbortedTestShouldFailDocker(t *testing.T) {
 
 func TestIncompatibleRun(t *testing.T) {
 	err := runSingle(t,
+		&terminateOpts{
+			runner:  "local:docker",
+			builder: "exec:go",
+		},
 		"run",
 		"single",
 		"--builder",
@@ -66,6 +78,10 @@ func TestIncompatibleRun(t *testing.T) {
 
 func TestCompatibleRunLocal(t *testing.T) {
 	err := runSingle(t,
+		&terminateOpts{
+			runner:  "local:exec",
+			builder: "exec:go",
+		},
 		"run",
 		"single",
 		"--builder",
@@ -87,6 +103,10 @@ func TestCompatibleRunLocal(t *testing.T) {
 
 func TestCompatibleRunDocker(t *testing.T) {
 	err := runSingle(t,
+		&terminateOpts{
+			runner:  "local:docker",
+			builder: "docker:go",
+		},
 		"run",
 		"single",
 		"--builder",
@@ -109,6 +129,9 @@ func TestCompatibleRunDocker(t *testing.T) {
 // example:artifact *only* works with docker:generic
 func TestDockerGenericCustomizesImage(t *testing.T) {
 	err := runSingle(t,
+		&terminateOpts{
+			runner: "local:docker",
+		},
 		"run",
 		"single",
 		"--builder",

--- a/pkg/cmd/itest/sidecar_test.go
+++ b/pkg/cmd/itest/sidecar_test.go
@@ -7,7 +7,7 @@ import (
 func TestSidecar(t *testing.T) {
 	t.Skip("Skipping flaky test")
 
-	err := runSingle(t,
+	err := runSingle(t, nil,
 		"run",
 		"single",
 		"--builder",

--- a/pkg/healthcheck/checkers.go
+++ b/pkg/healthcheck/checkers.go
@@ -118,6 +118,19 @@ func CheckK8sPods(ctx context.Context, client *kubernetes.Clientset, label strin
 	}
 }
 
+// CheckRedisPort returns a checker which verifies if the default port of redis (6379) is already binded
+// on localhost. If it is, it fails. If not, it succeeds.
+func CheckRedisPort() Checker {
+	return func() (bool, string, error) {
+		ln, err := net.Listen("tcp", "localhost:6379")
+		if err != nil {
+			return false, "local port 6379 is already occupied; please stop any local Redis instances first.", nil
+		}
+		ln.Close()
+		return true, "local port 6379 is free.", nil
+	}
+}
+
 // All returns a Checker that succeeds when all provided Checkers succeed.
 // If a Checker fails, it short-circuits and returns the first failure.
 func All(checkers ...Checker) Checker {

--- a/pkg/healthcheck/fixers.go
+++ b/pkg/healthcheck/fixers.go
@@ -84,7 +84,14 @@ func CreateDirectory(path string) Fixer {
 // NotImplemented is a placeholder Fixer which always returns successfully.
 func NotImplemented() Fixer {
 	return func() (string, error) {
-		return "fix is not implemented", nil
+		return "fix is not implemented.", nil
+	}
+}
+
+// RequiresManualFixing is a placeholder Fixer which always returns unsuccessfully.
+func RequiresManualFixing() Fixer {
+	return func() (string, error) {
+		return "requires manual fixing.", fmt.Errorf("requires manual fixing")
 	}
 }
 

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -56,6 +56,11 @@ func (r *LocalExecutableRunner) Healthcheck(ctx context.Context, engine api.Engi
 	r.outputsDir = filepath.Join(engine.EnvConfig().Dirs().Outputs(), "local_exec")
 	hh := &healthcheck.Helper{}
 
+	hh.Enlist("redis-ports",
+		healthcheck.CheckRedisPort(),
+		healthcheck.RequiresManualFixing(),
+	)
+
 	// setup infra which is common between local:docker and local:exec
 	localCommonHealthcheck(ctx, hh, cli, ow, "testground-control", r.outputsDir)
 

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -56,8 +56,8 @@ func (r *LocalExecutableRunner) Healthcheck(ctx context.Context, engine api.Engi
 	r.outputsDir = filepath.Join(engine.EnvConfig().Dirs().Outputs(), "local_exec")
 	hh := &healthcheck.Helper{}
 
-	hh.Enlist("redis-ports",
-		healthcheck.CheckRedisPort(),
+	hh.Enlist("redis-port",
+		healthcheck.CheckRedisPort(ctx, ow, cli),
 		healthcheck.RequiresManualFixing(),
 	)
 


### PR DESCRIPTION
This closes #959 by adding a healthcheck rule to `local:exec` that fails if the default redis port is unavailable, aborting the healthchecker.

I wasn't sure if we should abort or just fail because just failing the healthchecker would give the user a warning and not much information. This way it is clearer that local redis instances need to be  stopped.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>