### PR TITLE
docs: add `build_base_image` to dockercustomize manifest

### DIFF
--- a/plans/dockercustomize/manifest.toml
+++ b/plans/dockercustomize/manifest.toml
@@ -7,6 +7,7 @@ runner = "local:docker"
 [builders."docker:go"]
 enabled = true
 runtime_image = "debian"
+build_base_image = "golang:1.14.4-buster"
 enable_go_build_cache = true
 # skip_runtime_image = true
 


### PR DESCRIPTION
- Related to https://github.com/testground/testground/pull/1081