### PR TITLE
docker:go: replace rolling cache by static cache

### DIFF
--- a/pkg/api/builder.go
+++ b/pkg/api/builder.go
@@ -19,7 +19,7 @@ type Builder interface {
 	Build(ctx context.Context, input *BuildInput, ow *rpc.OutputWriter) (*BuildOutput, error)
 
 	// Purge frees resources, such as caches.
-	Purge(ctx context.Context, testplan string) error
+	Purge(ctx context.Context, testplan string, ow *rpc.OutputWriter) error
 
 	// ConfigType returns the configuration type of this builder.
 	ConfigType() reflect.Type

--- a/pkg/api/builder.go
+++ b/pkg/api/builder.go
@@ -18,6 +18,9 @@ type Builder interface {
 	// Build performs a build.
 	Build(ctx context.Context, input *BuildInput, ow *rpc.OutputWriter) (*BuildOutput, error)
 
+	// Purge frees resources, such as caches.
+	Purge(ctx context.Context, testplan string) error
+
 	// ConfigType returns the configuration type of this builder.
 	ConfigType() reflect.Type
 }

--- a/pkg/api/engine.go
+++ b/pkg/api/engine.go
@@ -42,6 +42,7 @@ type Engine interface {
 	ListRunners() map[string]Runner
 
 	DoBuild(context.Context, *Composition, *UnpackedSources, *rpc.OutputWriter) ([]*BuildOutput, error)
+	DoBuildPurge(ctx context.Context, builder, plan string, ow *rpc.OutputWriter) error
 	DoRun(context.Context, *Composition, *rpc.OutputWriter) (*RunOutput, error)
 	DoCollectOutputs(ctx context.Context, runner string, runID string, ow *rpc.OutputWriter) error
 	DoTerminate(ctx context.Context, ctype ComponentType, ref string, ow *rpc.OutputWriter) error

--- a/pkg/api/rpc.go
+++ b/pkg/api/rpc.go
@@ -38,6 +38,11 @@ type HealthcheckRequest struct {
 	Fix    bool   `json:"fix"`
 }
 
+type BuildPurgeRequest struct {
+	Builder  string `json:"builder"`
+	Testplan string `json:"testplan"`
+}
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // ~~~~~~ Response payloads ~~~~~~
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pkg/build/docker_generic.go
+++ b/pkg/build/docker_generic.go
@@ -97,6 +97,6 @@ func (*DockerGenericBuilder) ConfigType() reflect.Type {
 	return reflect.TypeOf(DockerGenericBuilderConfig{})
 }
 
-func (*DockerGenericBuilder) Purge(ctx context.Context, testplan string) error {
+func (*DockerGenericBuilder) Purge(ctx context.Context, testplan string, ow *rpc.OutputWriter) error {
 	return fmt.Errorf("purge not implemented for docker:generic")
 }

--- a/pkg/build/docker_generic.go
+++ b/pkg/build/docker_generic.go
@@ -96,3 +96,7 @@ func (*DockerGenericBuilder) ID() string {
 func (*DockerGenericBuilder) ConfigType() reflect.Type {
 	return reflect.TypeOf(DockerGenericBuilderConfig{})
 }
+
+func (*DockerGenericBuilder) Purge(ctx context.Context, testplan string) error {
+	return fmt.Errorf("purge not implemented for docker:generic")
+}

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -439,7 +439,7 @@ func (b *DockerGoBuilder) resolveBuildCacheImage(ctx context.Context, cli *clien
 		return true, nil
 	}
 
-	ow.Info("build cache image not found", "cache_image", cacheImage)
+	ow.Infow("build cache image not found", "cache_image", cacheImage)
 	return false, nil
 }
 

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -513,7 +513,7 @@ func (b *DockerGoBuilder) parseBuildCacheOutputImage(output string) string {
 	return ""
 }
 
-func (b *DockerGoBuilder) Purge(ctx context.Context, testplan string) error {
+func (b *DockerGoBuilder) Purge(ctx context.Context, testplan string, ow *rpc.OutputWriter) error {
 	cliopts := []client.Opt{client.FromEnv, client.WithAPIVersionNegotiation()}
 	cli, err := client.NewClientWithOpts(cliopts...)
 
@@ -525,7 +525,12 @@ func (b *DockerGoBuilder) Purge(ctx context.Context, testplan string) error {
 	}
 
 	cacheimage := fmt.Sprintf("tg-gobuildcache-%s", testplan)
-	return b.removeBuildCacheImage(ctx, cli, cacheimage)
+	err = b.removeBuildCacheImage(ctx, cli, cacheimage)
+	if err != nil {
+		return err
+	}
+	ow.Infow("removed cached imaged", "image", cacheimage)
+	return nil
 }
 
 const DockerfileTemplate = `

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -229,11 +229,13 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 	}
 
 	var baseimage string
+	var alreadyCached bool
 	if cfg.EnableGoBuildCache {
 		baseimage, err = b.resolveBuildCacheImage(ctx, cli, in, cfg, ow)
 		if err != nil {
 			return nil, err
 		}
+		alreadyCached = true
 	} else {
 		baseimage = cfg.BuildBaseImage
 	}
@@ -273,7 +275,7 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 
 	ow.Infow("build completed", "default_tag", fmt.Sprintf("%s:latest", in.BuildID), "took", time.Since(buildStart).Truncate(time.Second))
 
-	if cfg.EnableGoBuildCache {
+	if cfg.EnableGoBuildCache && !alreadyCached {
 		newCacheImageID := b.parseBuildCacheOutputImage(buildOutput)
 		if newCacheImageID == "" {
 			ow.Warnf("failed to locate go build cache output container")

--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -122,3 +122,7 @@ func (*ExecGoBuilder) ID() string {
 func (*ExecGoBuilder) ConfigType() reflect.Type {
 	return reflect.TypeOf(ExecGoBuilderConfig{})
 }
+
+func (*ExecGoBuilder) Purge(ctx context.Context, testplan string) error {
+	return fmt.Errorf("purge not implemented for exec:go")
+}

--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -123,6 +123,6 @@ func (*ExecGoBuilder) ConfigType() reflect.Type {
 	return reflect.TypeOf(ExecGoBuilderConfig{})
 }
 
-func (*ExecGoBuilder) Purge(ctx context.Context, testplan string) error {
+func (*ExecGoBuilder) Purge(ctx context.Context, testplan string, ow *rpc.OutputWriter) error {
 	return fmt.Errorf("purge not implemented for exec:go")
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -260,6 +260,17 @@ func (c *Client) Healthcheck(ctx context.Context, r *api.HealthcheckRequest) (io
 	return c.request(ctx, "POST", "/healthcheck", bytes.NewReader(body.Bytes()))
 }
 
+// BuildPurge sends a `build/purge` request to the daemon.
+func (c *Client) BuildPurge(ctx context.Context, r *api.BuildPurgeRequest) (io.ReadCloser, error) {
+	var body bytes.Buffer
+	err := json.NewEncoder(&body).Encode(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.request(ctx, "POST", "/build/purge", bytes.NewReader(body.Bytes()))
+}
+
 func parseGeneric(r io.ReadCloser, fnProgress, fnBinary, fnResult func(interface{}) error) error {
 	var chunk rpc.Chunk
 	var once sync.Once
@@ -360,6 +371,18 @@ func ParseBuildResponse(r io.ReadCloser) (api.BuildResponse, error) {
 		},
 	)
 	return resp, err
+}
+
+// ParseBuildPurgeResponse parses a response from 'build/purge' call.
+func ParseBuildPurgeResponse(r io.ReadCloser) error {
+	return parseGeneric(
+		r,
+		printProgress,
+		nil,
+		func(result interface{}) error {
+			return nil
+		},
+	)
 }
 
 // ParseTerminateRequest parses a response from a 'terminate' call

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -71,6 +71,7 @@ func New(cfg *config.EnvConfig) (srv *Daemon, err error) {
 	})
 
 	r.HandleFunc("/build", srv.buildHandler(engine)).Methods("POST")
+	r.HandleFunc("/build/purge", srv.buildPurgeHandler(engine)).Methods("POST")
 	r.HandleFunc("/run", srv.runHandler(engine)).Methods("POST")
 	r.HandleFunc("/outputs", srv.outputsHandler(engine)).Methods("POST")
 	r.HandleFunc("/terminate", srv.terminateHandler(engine)).Methods("POST")

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -433,6 +433,14 @@ func (e *Engine) DoHealthcheck(ctx context.Context, runner string, fix bool, ow 
 	return hc.Healthcheck(ctx, e, ow, fix)
 }
 
+func (e *Engine) DoBuildPurge(ctx context.Context, builder, plan string, ow *rpc.OutputWriter) error {
+	bm, ok := e.builders[builder]
+	if !ok {
+		return fmt.Errorf("unrecognized builder: %s", builder)
+	}
+	return bm.Purge(ctx, plan, ow)
+}
+
 // EnvConfig returns the EnvConfig for this Engine.
 func (e *Engine) EnvConfig() config.EnvConfig {
 	return *e.envcfg


### PR DESCRIPTION
This PR closes #1088 by removing the rolling cache mechanism and replacing it by a more manual cache process. Now, the cached image is only built once and the developer decides when to reset/clear the cached image.

To enable the cache, the option `enable_go_build_cache` must be set to true, just like it is done right now. When it's true, two things can happen:

1. If there's no cached image, we cache the intermediate later right before the runtime phase.
2. If there's a cached image, use it as a base.

To clear up the cache, you can run:

```
testground build purge --builder docker:go --plan <test-plan-name>
```