### PR TITLE
allow https endpoints for daemon

### DIFF
--- a/env-example.toml
+++ b/env-example.toml
@@ -41,4 +41,4 @@ ulimits = [
 listen = ":8080"
 
 [client]
-endpoint = "localhost:8080"
+endpoint = "http://localhost:8080"

--- a/env-kind.toml
+++ b/env-kind.toml
@@ -16,4 +16,4 @@ ulimits = [
 listen = ":8080"
 
 [client]
-endpoint = "localhost:8080"
+endpoint = "http://localhost:8080"

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -394,7 +394,7 @@ func (c *Client) request(ctx context.Context, method string, path string, body i
 	if len(headers)%2 != 0 {
 		return nil, fmt.Errorf("headers must be tuples: key1, value1, key2, value2")
 	}
-	req, err := http.NewRequest(method, "http://"+c.endpoint+path, body)
+	req, err := http.NewRequest(method, c.endpoint+path, body)
 	req = req.WithContext(ctx)
 
 	token := strings.TrimSpace(c.cfg.Client.Token)

--- a/pkg/cmd/itest/common_test.go
+++ b/pkg/cmd/itest/common_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/testground/testground/pkg/cmd"
@@ -38,17 +39,19 @@ func runSingle(t *testing.T, opts *terminateOpts, args ...string) error {
 	app.Flags = cmd.RootFlags
 	app.HideVersion = true
 
-	args = append([]string{"testground", "--endpoint", srv.Addr()}, args...)
+	endpoint := fmt.Sprintf("http://%s", srv.Addr())
+
+	args = append([]string{"testground", "--endpoint", endpoint}, args...)
 	err = app.Run(args)
 
 	if opts != nil {
 		if opts.builder != "" {
-			args = []string{"testground", "--endpoint", srv.Addr(), "terminate", "--builder", opts.builder}
+			args = []string{"testground", "--endpoint", endpoint, "terminate", "--builder", opts.builder}
 			_ = app.Run(args)
 		}
 
 		if opts.runner != "" {
-			args = []string{"testground", "--endpoint", srv.Addr(), "terminate", "--runner", opts.runner}
+			args = []string{"testground", "--endpoint", endpoint, "terminate", "--runner", opts.runner}
 			_ = app.Run(args)
 		}
 	}


### PR DESCRIPTION
This PR is updating the endpoint format in `.env.toml` so that we can specify `https` endpoints, and have a Testground daemon exposed on the internet (with https://github.com/testground/infra/pull/58)