### PR TITLE
cluster:k8s: implement traffic policies

### DIFF
--- a/pkg/sidecar/docker_reactor.go
+++ b/pkg/sidecar/docker_reactor.go
@@ -202,7 +202,7 @@ func (d *DockerReactor) handleContainer(ctx context.Context, container *docker.C
 		container:       container,
 		activeLinks:     make(map[string]*dockerLink, len(info.NetworkSettings.Networks)),
 		availableLinks:  make(map[string]string, len(networks)),
-		externalRouting: map[string]*dockerRouting{},
+		externalRouting: map[string]*route{},
 		nl:              netlinkHandle,
 	}
 
@@ -246,7 +246,7 @@ func (d *DockerReactor) handleContainer(ctx context.Context, container *docker.C
 		// We've found a control network (or some other network).
 
 		// Get all current routes and store them.
-		routes, err := dockerRoutes(link, netlinkHandle)
+		routes, err := getDockerRoutes(link, netlinkHandle)
 		if err != nil {
 			return nil, fmt.Errorf("failed to enumerate routes: %w", err)
 		}

--- a/pkg/sidecar/k8s_reactor.go
+++ b/pkg/sidecar/k8s_reactor.go
@@ -205,12 +205,13 @@ func (d *K8sReactor) manageContainer(ctx context.Context, container *docker.Cont
 
 	// Finally, construct the network manager.
 	network := &K8sNetwork{
-		netnsPath:   fmt.Sprintf("/proc/%d/ns/net", info.State.Pid),
-		cninet:      cninet,
-		container:   container,
-		subnet:      runenv.TestSubnet.String(),
-		nl:          netlinkHandle,
-		activeLinks: make(map[string]*k8sLink),
+		netnsPath:       fmt.Sprintf("/proc/%d/ns/net", info.State.Pid),
+		cninet:          cninet,
+		container:       container,
+		subnet:          runenv.TestSubnet.String(),
+		nl:              netlinkHandle,
+		activeLinks:     make(map[string]*k8sLink),
+		externalRouting: map[string]*route{},
 	}
 
 	// Remove all routes but redis and the data subnet
@@ -317,7 +318,7 @@ func (d *K8sReactor) manageContainer(ctx context.Context, container *docker.Cont
 			logging.S().Warnw("failed to really delete route", "route.Src", r.Src, "gw", r.Gw, "route.Dst", routeDst, "container", container.ID, "err", err.Error())
 		}
 		if err := netlinkHandle.RouteAdd(&bh); err != nil {
-			logging.S().Warnw("failed to add blackhole route")
+			logging.S().Warnw("failed to add blackhole route", "err", err.Error())
 		}
 	}
 


### PR DESCRIPTION
Closes #1116. To implement the AllowAll and BlockAll traffic policies on k8s, I followed a similar approach to what was done in #1107: saved the external routes on the data plan, which uses Weave plugin, and we now remove the default route when we want to block external traffic, or add it when we want to allow it.

I run a few tests to make sure this doesn't break container-to-container communication in other tests. I hope it makes sense. They all passed!

## Tests Run

<details>
<summary>
network/traffic-allowed
</summary>

```
$ testground run single --builder docker:go \
	--runner cluster:k8s \
	-i 1 --plan network --testcase traffic-allowed \
	--collect
```


**Output:**

```
{"ts":1596635995586585358,"msg":"","group_id":"single","run_id":"0fb1e476d206","event":{"type":"message","message":"registering default http handler at: http://[::]:6060/ (pprof: http://[::]:6060/debug/pprof/)"}}
{"ts":1596635995586622501,"msg":"","group_id":"single","run_id":"0fb1e476d206","event":{"type":"start","runenv":{"plan":"network","case":"traffic-allowed","run":"0fb1e476d206","params":{},"instances":1,"outputs_path":"/outputs/0fb1e476d206/single/0","network":"23.221.0.0/16","group":"single","group_instances":1}}}
{"ts":1596635995593813780,"msg":"","group_id":"single","run_id":"0fb1e476d206","event":{"type":"message","message":"before sync.MustBoundClient"}}
{"ts":1596635995595984848,"msg":"","group_id":"single","run_id":"0fb1e476d206","event":{"type":"message","message":"before netclient.MustWaitNetworkInitialized"}}
{"ts":1596635998597001751,"msg":"","group_id":"single","run_id":"0fb1e476d206","event":{"type":"message","message":"network initialisation successful"}}
{"ts":1596635998599327689,"msg":"","group_id":"single","run_id":"0fb1e476d206","event":{"type":"message","message":"before netclient.MustConfigureNetwork"}}
{"ts":1596635999650003460,"msg":"","group_id":"single","run_id":"0fb1e476d206","event":{"type":"message","message":"received message: hello world\n"}}
{"ts":1596635999650165193,"msg":"","group_id":"single","run_id":"0fb1e476d206","event":{"type":"finish","outcome":"ok"}}
```
</details>

<details>
<summary>
network/traffic-blocked
</summary>

```
$ testground run single --builder docker:go \
	--runner cluster:k8s \
	-i 1 --plan network --testcase traffic-blocked \
	--collect
```

**Output:**

```
{"ts":1596636117354291711,"msg":"","group_id":"single","run_id":"a5ee4b793d58","event":{"type":"message","message":"registering default http handler at: http://[::]:6060/ (pprof: http://[::]:6060/debug/pprof/)"}}
{"ts":1596636117354332172,"msg":"","group_id":"single","run_id":"a5ee4b793d58","event":{"type":"start","runenv":{"plan":"network","case":"traffic-blocked","run":"a5ee4b793d58","params":{},"instances":1,"outputs_path":"/outputs/a5ee4b793d58/single/0","network":"23.222.0.0/16","group":"single","group_instances":1}}}
{"ts":1596636117362460411,"msg":"","group_id":"single","run_id":"a5ee4b793d58","event":{"type":"message","message":"before sync.MustBoundClient"}}
{"ts":1596636117364868890,"msg":"","group_id":"single","run_id":"a5ee4b793d58","event":{"type":"message","message":"before netclient.MustWaitNetworkInitialized"}}
{"ts":1596636120365916193,"msg":"","group_id":"single","run_id":"a5ee4b793d58","event":{"type":"message","message":"network initialisation successful"}}
{"ts":1596636120368012160,"msg":"","group_id":"single","run_id":"a5ee4b793d58","event":{"type":"message","message":"before netclient.MustConfigureNetwork"}}
{"ts":1596636121399053379,"msg":"","group_id":"single","run_id":"a5ee4b793d58","event":{"type":"message","message":"connection failed as expected: Get \"https://bafybeicg2rebjoofv4kbyovkw7af3rpiitvnl6i7ckcywaq6xjcxnc2mby.ipfs.dweb.link/\": dial tcp [2602:fea2:2::1]:443: connect: cannot assign requested address"}}
{"ts":1596636121399180146,"msg":"","group_id":"single","run_id":"a5ee4b793d58","event":{"type":"finish","outcome":"ok"}}
```
</details>

<details>
<summary>
network/ping-pong
</summary>

```
$ testground run single --builder docker:go \
	--runner cluster:k8s \
	-i 2 --plan network --testcase ping-pong \
	--collect
```

**Output (Instance 0):**

```
{"ts":1596636178379091740,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"registering default http handler at: http://[::]:6060/ (pprof: http://[::]:6060/debug/pprof/)"}}
{"ts":1596636178379126796,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"start","runenv":{"plan":"network","case":"ping-pong","run":"27c1d2270a36","params":{},"instances":2,"outputs_path":"/outputs/27c1d2270a36/single/0","network":"23.223.0.0/16","group":"single","group_instances":2}}}
{"ts":1596636178388705931,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"before sync.MustBoundClient"}}
{"ts":1596636178390641181,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"before netclient.MustWaitNetworkInitialized"}}
{"ts":1596636181391224541,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"network initialisation successful"}}
{"ts":1596636181392588990,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"before netclient.MustConfigureNetwork"}}
{"ts":1596636183394429463,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"I am 1"}}
{"ts":1596636183394478370,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"before reconfiguring network"}}
{"ts":1596636184395274352,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"waiting until ready"}}
{"ts":1596636184395316642,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"writing my id"}}
{"ts":1596636184395330003,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"reading their id"}}
{"ts":1596636184596202824,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"returning their id"}}
{"ts":1596636184596252865,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"reading my id"}}
{"ts":1596636184596258380,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"done"}}
{"ts":1596636184596271897,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"ping RTT was 200.945278ms [200ms, 215ms]"}}
{"ts":1596636186598090344,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"ping pong"}}
{"ts":1596636186598136513,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"waiting until ready"}}
{"ts":1596636186598154805,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"writing my id"}}
{"ts":1596636186598162332,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"reading their id"}}
{"ts":1596636186618940044,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"returning their id"}}
{"ts":1596636186618987365,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"reading my id"}}
{"ts":1596636186618996041,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"done"}}
{"ts":1596636186619005886,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"ping RTT was 20.844792ms [20ms, 35ms]"}}
{"ts":1596636187619968650,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"finish","outcome":"ok"}}
```

**Output (Instance 1):**

```
{"ts":1596636178717884206,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"registering default http handler at: http://[::]:6060/ (pprof: http://[::]:6060/debug/pprof/)"}}
{"ts":1596636178717920949,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"start","runenv":{"plan":"network","case":"ping-pong","run":"27c1d2270a36","params":{},"instances":2,"outputs_path":"/outputs/27c1d2270a36/single/1","network":"23.223.0.0/16","group":"single","group_instances":2}}}
{"ts":1596636178723827856,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"before sync.MustBoundClient"}}
{"ts":1596636178726235983,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"before netclient.MustWaitNetworkInitialized"}}
{"ts":1596636181727240162,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"network initialisation successful"}}
{"ts":1596636181729686710,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"before netclient.MustConfigureNetwork"}}
{"ts":1596636182733140552,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"I am 2"}}
{"ts":1596636182733173310,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"before reconfiguring network"}}
{"ts":1596636184136886753,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"waiting until ready"}}
{"ts":1596636184496166350,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"writing my id"}}
{"ts":1596636184496205848,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"reading their id"}}
{"ts":1596636184496213013,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"returning their id"}}
{"ts":1596636184496234763,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"reading my id"}}
{"ts":1596636184696952861,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"done"}}
{"ts":1596636184696997549,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"ping RTT was 200.824258ms [200ms, 215ms]"}}
{"ts":1596636185700259070,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"ping pong"}}
{"ts":1596636185700286848,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"waiting until ready"}}
{"ts":1596636186608958737,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"writing my id"}}
{"ts":1596636186609002613,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"reading their id"}}
{"ts":1596636186609009036,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"returning their id"}}
{"ts":1596636186609017806,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"reading my id"}}
{"ts":1596636186629647787,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"done"}}
{"ts":1596636186629665810,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"message","message":"ping RTT was 20.70471ms [20ms, 35ms]"}}
{"ts":1596636186631176348,"msg":"","group_id":"single","run_id":"27c1d2270a36","event":{"type":"finish","outcome":"ok"}}
```

</details>


<details>
<summary>
splitbrain/accept
</summary>

```
$ testground run single --builder docker:go \
	--runner cluster:k8s \
	-i 2 --plan splitbrain --testcase accept \
	--collect
```


**Output (Instance 0):**

```
{"ts":1596636558398284659,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"registering default http handler at: http://[::]:6060/ (pprof: http://[::]:6060/debug/pprof/)"}}
{"ts":1596636558398324531,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"start","runenv":{"plan":"splitbrain","case":"accept","run":"ae4f8bbbbbcb","params":{},"instances":2,"outputs_path":"/outputs/ae4f8bbbbbcb/single/0","network":"23.224.0.0/16","group":"single","group_instances":2}}}
{"ts":1596636559396592287,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"influxdb: uploaded 1 points"}}
{"ts":1596636564395942464,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636566406778033,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"network initialisation successful"}}
{"ts":1596636566406805846,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"Starting http server"}}
{"ts":1596636566407151896,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"127.0.0.1 not in data subnet 23.224.0.0/16, ignoring"}}
{"ts":1596636566407185327,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"100.96.1.7 not in data subnet 23.224.0.0/16, ignoring"}}
{"ts":1596636566407208563,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"detected data network IP: 23.224.0.1/16"}}
{"ts":1596636566407219505,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"my ip is 23.224.0.1 and I am in region region_C"}}
{"ts":1596636566407926503,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"received node (region_B) 23.224.192.0"}}
{"ts":1596636566407944519,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"received node (region_C) 23.224.0.1"}}
{"ts":1596636569395615379,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636574395817657,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636576408511015,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"(region region_C) contacting http://23.224.192.0:8765"}}
{"ts":1596636576410715261,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"received http request from 23.224.192.0:34484"}}
{"ts":1596636576412687781,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"could not connect 0"}}
{"ts":1596636576412704609,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"200 status codes 1"}}
{"ts":1596636576412709907,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"total, 1"}}
{"ts":1596636576413555943,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"finish","outcome":"ok"}}
{"ts":1596636576413622203,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"io closed"}}
{"ts":1596636576422547965,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"influxdb: uploaded 1 points"}}
```

**Output (Instance 1):**

```
{"ts":1596636562271503983,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"registering default http handler at: http://[::]:6060/ (pprof: http://[::]:6060/debug/pprof/)"}}
{"ts":1596636562271547004,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"start","runenv":{"plan":"splitbrain","case":"accept","run":"ae4f8bbbbbcb","params":{},"instances":2,"outputs_path":"/outputs/ae4f8bbbbbcb/single/1","network":"23.224.0.0/16","group":"single","group_instances":2}}}
{"ts":1596636563269005874,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"influxdb: uploaded 1 points"}}
{"ts":1596636566288752172,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"network initialisation successful"}}
{"ts":1596636566290922034,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"Starting http server"}}
{"ts":1596636566291773261,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"127.0.0.1 not in data subnet 23.224.0.0/16, ignoring"}}
{"ts":1596636566291814706,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"100.96.2.12 not in data subnet 23.224.0.0/16, ignoring"}}
{"ts":1596636566291846311,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"detected data network IP: 23.224.192.0/16"}}
{"ts":1596636566291859632,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"my ip is 23.224.192.0 and I am in region region_B"}}
{"ts":1596636566294001356,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"received node (region_B) 23.224.192.0"}}
{"ts":1596636566408365066,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"received node (region_C) 23.224.0.1"}}
{"ts":1596636568268239014,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636573268355207,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636576409909555,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"(region region_B) contacting http://23.224.0.1:8765"}}
{"ts":1596636576411582391,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"could not connect 0"}}
{"ts":1596636576411597817,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"200 status codes 1"}}
{"ts":1596636576411601539,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"total, 1"}}
{"ts":1596636576411327600,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"received http request from 23.224.0.1:38484"}}
{"ts":1596636577414148795,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"finish","outcome":"ok"}}
{"ts":1596636577414239938,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"io closed"}}
{"ts":1596636577424726743,"msg":"","group_id":"single","run_id":"ae4f8bbbbbcb","event":{"type":"message","message":"influxdb: uploaded 58 points"}}
```

</details>


<details>
<summary>
splitbrain/reject
</summary>

```
$ testground run single --builder docker:go \
	--runner cluster:k8s \
	-i 2 --plan splitbrain --testcase reject \
	--collect
```


**Output (Instance 0):**

```
{"ts":1596636692135365686,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"registering default http handler at: http://[::]:6060/ (pprof: http://[::]:6060/debug/pprof/)"}}
{"ts":1596636692135412380,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"start","runenv":{"plan":"splitbrain","case":"reject","run":"39be59fd821a","params":{},"instances":2,"outputs_path":"/outputs/39be59fd821a/single/0","network":"23.225.0.0/16","group":"single","group_instances":2}}}
{"ts":1596636693134006911,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"influxdb: uploaded 1 points"}}
{"ts":1596636695144655950,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"network initialisation successful"}}
{"ts":1596636695147151355,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"Starting http server"}}
{"ts":1596636695147949516,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"127.0.0.1 not in data subnet 23.225.0.0/16, ignoring"}}
{"ts":1596636695147984763,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"100.96.2.13 not in data subnet 23.225.0.0/16, ignoring"}}
{"ts":1596636695148004983,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"detected data network IP: 23.225.192.0/16"}}
{"ts":1596636695148011223,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"my ip is 23.225.192.0 and I am in region region_B"}}
{"ts":1596636695150012730,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"received node (region_B) 23.225.192.0"}}
{"ts":1596636695320046049,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"received node (region_C) 23.225.0.1"}}
{"ts":1596636698133772000,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636703133082772,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636705321501222,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"(region region_B) contacting http://23.225.0.1:8765"}}
{"ts":1596636705323296860,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"received http request from 23.225.0.1:52798"}}
{"ts":1596636705323719174,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"could not connect 0"}}
{"ts":1596636705323739345,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"200 status codes 1"}}
{"ts":1596636705323744616,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"total, 1"}}
{"ts":1596636705325792626,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"finish","outcome":"ok"}}
{"ts":1596636705325848497,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"io closed"}}
{"ts":1596636705337152179,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"influxdb: uploaded 1 points"}}
```

**Output (Instance 1):**

```
{"ts":1596636692304388449,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"registering default http handler at: http://[::]:6060/ (pprof: http://[::]:6060/debug/pprof/)"}}
{"ts":1596636692304419716,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"start","runenv":{"plan":"splitbrain","case":"reject","run":"39be59fd821a","params":{},"instances":2,"outputs_path":"/outputs/39be59fd821a/single/1","network":"23.225.0.0/16","group":"single","group_instances":2}}}
{"ts":1596636693303478226,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"influxdb: uploaded 1 points"}}
{"ts":1596636695316124433,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"network initialisation successful"}}
{"ts":1596636695318378334,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"Starting http server"}}
{"ts":1596636695318782005,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"127.0.0.1 not in data subnet 23.225.0.0/16, ignoring"}}
{"ts":1596636695318813182,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"100.96.1.8 not in data subnet 23.225.0.0/16, ignoring"}}
{"ts":1596636695318835489,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"detected data network IP: 23.225.0.1/16"}}
{"ts":1596636695318842309,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"my ip is 23.225.0.1 and I am in region region_C"}}
{"ts":1596636695319614574,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"received node (region_B) 23.225.192.0"}}
{"ts":1596636695319632177,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"received node (region_C) 23.225.0.1"}}
{"ts":1596636698302922836,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636703302443094,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636705320970331,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"(region region_C) contacting http://23.225.192.0:8765"}}
{"ts":1596636705322751534,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"received http request from 23.225.192.0:39876"}}
{"ts":1596636705323166128,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"could not connect 0"}}
{"ts":1596636705323181975,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"200 status codes 1"}}
{"ts":1596636705323187170,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"total, 1"}}
{"ts":1596636705323995364,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"finish","outcome":"ok"}}
{"ts":1596636705324041045,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"io closed"}}
{"ts":1596636705332135968,"msg":"","group_id":"single","run_id":"39be59fd821a","event":{"type":"message","message":"influxdb: uploaded 1 points"}}

```
</details>


<details>
<summary>
splitbrain/drop
</summary>

```
$ testground run single --builder docker:go \
	--runner cluster:k8s \
	-i 2 --plan splitbrain --testcase drop \
	--collect
```

**Output (Instance 0):**

```
{"ts":1596636770488278650,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"registering default http handler at: http://[::]:6060/ (pprof: http://[::]:6060/debug/pprof/)"}}
{"ts":1596636770488316321,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"start","runenv":{"plan":"splitbrain","case":"drop","run":"4989d8ee0b74","params":{},"instances":2,"outputs_path":"/outputs/4989d8ee0b74/single/0","network":"23.226.0.0/16","group":"single","group_instances":2}}}
{"ts":1596636771485856897,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"influxdb: uploaded 1 points"}}
{"ts":1596636773497632085,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"network initialisation successful"}}
{"ts":1596636773499710791,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"Starting http server"}}
{"ts":1596636773500550421,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"127.0.0.1 not in data subnet 23.226.0.0/16, ignoring"}}
{"ts":1596636773500583646,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"100.96.2.14 not in data subnet 23.226.0.0/16, ignoring"}}
{"ts":1596636773500611668,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"detected data network IP: 23.226.128.0/16"}}
{"ts":1596636773500621313,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"my ip is 23.226.128.0 and I am in region region_B"}}
{"ts":1596636773502746111,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"received node (region_B) 23.226.128.0"}}
{"ts":1596636773809424692,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"received node (region_C) 23.226.0.1"}}
{"ts":1596636776485318651,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636781485023834,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636783810982062,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"(region region_B) contacting http://23.226.0.1:8765"}}
{"ts":1596636783812564023,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"received http request from 23.226.0.1:42252"}}
{"ts":1596636783812608973,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"could not connect 0"}}
{"ts":1596636783812626563,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"200 status codes 1"}}
{"ts":1596636783812630349,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"total, 1"}}
{"ts":1596636783814885506,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"finish","outcome":"ok"}}
{"ts":1596636783814946087,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"io closed"}}
{"ts":1596636783824501324,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"influxdb: uploaded 1 points"}}
```

**Output (Instance 1):**

```
{"ts":1596636770791801146,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"registering default http handler at: http://[::]:6060/ (pprof: http://[::]:6060/debug/pprof/)"}}
{"ts":1596636770791848089,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"start","runenv":{"plan":"splitbrain","case":"drop","run":"4989d8ee0b74","params":{},"instances":2,"outputs_path":"/outputs/4989d8ee0b74/single/1","network":"23.226.0.0/16","group":"single","group_instances":2}}}
{"ts":1596636771789115115,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"influxdb: uploaded 1 points"}}
{"ts":1596636773806089736,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"network initialisation successful"}}
{"ts":1596636773807803336,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"Starting http server"}}
{"ts":1596636773808172361,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"127.0.0.1 not in data subnet 23.226.0.0/16, ignoring"}}
{"ts":1596636773808209530,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"100.96.1.9 not in data subnet 23.226.0.0/16, ignoring"}}
{"ts":1596636773808232212,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"detected data network IP: 23.226.0.1/16"}}
{"ts":1596636773808239268,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"my ip is 23.226.0.1 and I am in region region_C"}}
{"ts":1596636773809066307,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"received node (region_B) 23.226.128.0"}}
{"ts":1596636773809083968,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"received node (region_C) 23.226.0.1"}}
{"ts":1596636776788396439,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636781788143078,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"influxdb: uploaded 57 points"}}
{"ts":1596636783809644298,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"(region region_C) contacting http://23.226.128.0:8765"}}
{"ts":1596636783811699583,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"received http request from 23.226.128.0:39368"}}
{"ts":1596636783812457846,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"could not connect 0"}}
{"ts":1596636783812472540,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"200 status codes 1"}}
{"ts":1596636783812476671,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"total, 1"}}
{"ts":1596636783813282630,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"finish","outcome":"ok"}}
{"ts":1596636783813340537,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"io closed"}}
{"ts":1596636783820709040,"msg":"","group_id":"single","run_id":"4989d8ee0b74","event":{"type":"message","message":"influxdb: uploaded 1 points"}}
```

</details>
