### PR TITLE
fix: 'testground describe' does not have args

### DIFF
--- a/pkg/cmd/describe.go
+++ b/pkg/cmd/describe.go
@@ -13,8 +13,7 @@ import (
 var DescribeCommand = cli.Command{
 	Name:        "describe",
 	Usage:       "describe a test plan",
-	ArgsUsage:   "<plan name>",
-	Description: "Loads the test plan manifest from $TESTGROUND_HOME/plans/<plan name>, and explains its contents",
+	Description: "Loads the test plan manifest from $TESTGROUND_HOME/plans/<plan>, and explains its contents",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:     "plan",


### PR DESCRIPTION
The `describe` command uses flags and not arguments. Let's fix that help text!

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>