### PR TITLE
fix: local_exec path injection 

### DIFF
--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -124,6 +124,7 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 			env := conv.ToOptionsSlice(runenv.ToEnvVars())
 			env = append(env, "INFLUXDB_URL=http://localhost:8086")
 			env = append(env, "REDIS_HOST=localhost")
+			env = append(env, "PATH="+os.Getenv("PATH"))
 
 			ow.Infow("starting test case instance", "plan", input.TestPlan, "group", g.ID, "number", i, "total", total)
 


### PR DESCRIPTION
PATH was not being injected and led to error over Linux:
```
Aug 13 09:20:04.939750  INFO    0.0707s       FAIL << instance   2 >> exec: "getent": executable file not found in $PATH       {"req_id": "0ad73835"}
```