### PR TITLE
initial notification to slack on completed task ; basic html pages for tasks and logs

### DIFF
--- a/pkg/api/engine.go
+++ b/pkg/api/engine.go
@@ -5,6 +5,7 @@ import (
 	"github.com/testground/testground/pkg/config"
 	"github.com/testground/testground/pkg/rpc"
 	"github.com/testground/testground/pkg/task"
+	"time"
 )
 
 type ComponentType string
@@ -35,8 +36,12 @@ type UnpackedSources struct {
 }
 
 type TasksFilters struct {
-	Types  []task.Type
-	States []task.State
+	Types    []task.Type
+	States   []task.State
+	After    *time.Time
+	Before   *time.Time
+	TestPlan string
+	TestCase string
 }
 
 type Engine interface {

--- a/pkg/api/rpc.go
+++ b/pkg/api/rpc.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+
 	"github.com/testground/testground/pkg/task"
 )
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -7,8 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/logrusorgru/aurora"
-	"github.com/testground/testground/pkg/task"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -19,6 +17,9 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/testground/testground/pkg/task"
 
 	"github.com/testground/testground/pkg/api"
 	"github.com/testground/testground/pkg/config"
@@ -494,7 +495,7 @@ func ParseStatusResponse(r io.ReadCloser) (api.StatusResponse, error) {
 }
 
 // ParseLogsRequest parses a response from a 'logs' call
-func ParseLogsRequest(r io.ReadCloser) (api.LogsResponse, error) {
+func ParseLogsRequest(w io.Writer, r io.ReadCloser) (api.LogsResponse, error) {
 	var resp api.LogsResponse
 	err := parseGeneric(
 		r,
@@ -519,7 +520,7 @@ func ParseLogsRequest(r io.ReadCloser) (api.LogsResponse, error) {
 				return err
 			}
 
-			fmt.Print(string(m))
+			fmt.Fprint(w, string(m))
 			return nil
 		},
 		nil,

--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"os"
 	"path/filepath"
+
+	"github.com/mitchellh/mapstructure"
 
 	"github.com/testground/testground/pkg/api"
 	"github.com/testground/testground/pkg/client"
@@ -247,7 +248,7 @@ func doBuild(c *cli.Context, comp *api.Composition) error {
 	}
 	defer r.Close()
 
-	tsk, err := client.ParseLogsRequest(r)
+	tsk, err := client.ParseLogsRequest(os.Stdout, r)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"os"
+
 	"github.com/testground/testground/pkg/api"
 	"github.com/testground/testground/pkg/client"
 	"github.com/urfave/cli/v2"
@@ -44,7 +46,7 @@ func logsCommand(c *cli.Context) error {
 	}
 	defer r.Close()
 
-	tsk, err := client.ParseLogsRequest(r)
+	tsk, err := client.ParseLogsRequest(os.Stdout, r)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/mitchellh/mapstructure"
 	"github.com/testground/testground/pkg/api"
 	"github.com/testground/testground/pkg/client"
 	"github.com/testground/testground/pkg/logging"
-	"os"
-	"path/filepath"
 
 	"github.com/BurntSushi/toml"
 	"github.com/urfave/cli/v2"
@@ -231,7 +232,7 @@ func doRun(c *cli.Context, comp *api.Composition) (err error) {
 	}
 	defer r.Close()
 
-	tsk, err := client.ParseLogsRequest(r)
+	tsk, err := client.ParseLogsRequest(os.Stdout, r)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tasks.go
+++ b/pkg/cmd/tasks.go
@@ -45,12 +45,12 @@ func tasksCommand(c *cli.Context) error {
 		return err
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 
-	fmt.Fprintln(w, "ID\tState\tType")
+	fmt.Fprintln(w, "ID\tDATE\tTEST PLAN\tTEST CASE\tDURATION\tSTATE\tTYPE")
 
 	for _, tsk := range tsks {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", tsk.ID, tsk.State().State, tsk.Type)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", tsk.ID, tsk.Created().String(), tsk.Plan, tsk.Case, tsk.Took(), tsk.State().State, tsk.Type)
 	}
 
 	w.Flush()

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -36,11 +36,12 @@ type DockerHubConfig struct {
 }
 
 type DaemonConfig struct {
-	Listen        string   `toml:"listen"`
-	Tokens        []string `toml:"tokens"`
-	Workers       int      `toml:"workers"`
-	QueueSize     int      `toml:"queue_size"`
-	TasksInMemory bool     `toml:"tasks_in_memory"`
+	Listen          string   `toml:"listen"`
+	Tokens          []string `toml:"tokens"`
+	Workers         int      `toml:"workers"`
+	QueueSize       int      `toml:"queue_size"`
+	TasksInMemory   bool     `toml:"tasks_in_memory"`
+	SlackWebhookURL string   `toml:"slack_webhook_url"`
 }
 
 type ClientConfig struct {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -74,6 +74,7 @@ func New(cfg *config.EnvConfig) (srv *Daemon, err error) {
 	r.HandleFunc("/build/purge", srv.buildPurgeHandler(engine)).Methods("POST")
 	r.HandleFunc("/run", srv.runHandler(engine)).Methods("POST")
 	r.HandleFunc("/outputs", srv.outputsHandler(engine)).Methods("POST")
+	r.HandleFunc("/outputs", srv.getOutputsHandler(engine)).Methods("GET")
 	r.HandleFunc("/terminate", srv.terminateHandler(engine)).Methods("POST")
 	r.HandleFunc("/healthcheck", srv.healthcheckHandler(engine)).Methods("POST")
 	r.HandleFunc("/tasks", srv.tasksHandler(engine)).Methods("POST")

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -70,18 +70,19 @@ func New(cfg *config.EnvConfig) (srv *Daemon, err error) {
 		})
 	})
 
+	r.HandleFunc("/tasks", srv.listTasksHandler(engine)).Methods("GET")
+	r.HandleFunc("/logs", srv.getLogsHandler(engine)).Methods("GET")
+	r.HandleFunc("/outputs", srv.getOutputsHandler(engine)).Methods("GET")
+
 	r.HandleFunc("/build", srv.buildHandler(engine)).Methods("POST")
 	r.HandleFunc("/build/purge", srv.buildPurgeHandler(engine)).Methods("POST")
 	r.HandleFunc("/run", srv.runHandler(engine)).Methods("POST")
 	r.HandleFunc("/outputs", srv.outputsHandler(engine)).Methods("POST")
-	r.HandleFunc("/outputs", srv.getOutputsHandler(engine)).Methods("GET")
 	r.HandleFunc("/terminate", srv.terminateHandler(engine)).Methods("POST")
 	r.HandleFunc("/healthcheck", srv.healthcheckHandler(engine)).Methods("POST")
 	r.HandleFunc("/tasks", srv.tasksHandler(engine)).Methods("POST")
-	r.HandleFunc("/tasks", srv.listTasksHandler(engine)).Methods("GET")
 	r.HandleFunc("/status", srv.statusHandler(engine)).Methods("POST")
 	r.HandleFunc("/logs", srv.logsHandler(engine)).Methods("POST")
-	r.HandleFunc("/logs", srv.getLogsHandler(engine)).Methods("GET")
 
 	srv.doneCh = make(chan struct{})
 	srv.server = &http.Server{

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -77,8 +77,10 @@ func New(cfg *config.EnvConfig) (srv *Daemon, err error) {
 	r.HandleFunc("/terminate", srv.terminateHandler(engine)).Methods("POST")
 	r.HandleFunc("/healthcheck", srv.healthcheckHandler(engine)).Methods("POST")
 	r.HandleFunc("/tasks", srv.tasksHandler(engine)).Methods("POST")
+	r.HandleFunc("/tasks", srv.listTasksHandler(engine)).Methods("GET")
 	r.HandleFunc("/status", srv.statusHandler(engine)).Methods("POST")
 	r.HandleFunc("/logs", srv.logsHandler(engine)).Methods("POST")
+	r.HandleFunc("/logs", srv.getLogsHandler(engine)).Methods("GET")
 
 	srv.doneCh = make(chan struct{})
 	srv.server = &http.Server{

--- a/pkg/daemon/logs.go
+++ b/pkg/daemon/logs.go
@@ -62,18 +62,19 @@ func (d *Daemon) getLogsHandler(engine api.Engine) func(w http.ResponseWriter, r
 		go func() {
 			_, err := client.ParseLogsRequest(brWriter{w}, rr)
 			if err != nil {
-				fmt.Fprintf(w, "error while parsing logs", "err", err.Error())
+				fmt.Fprintf(w, "error while parsing logs: %s", err.Error())
 			}
 		}()
 
 		_, err := engine.Logs(r.Context(), req.TaskID, req.Follow, req.CancelWithContext, tgw)
 		if err != nil {
-			fmt.Fprintf(w, "error while fetching logs", "err", err.Error())
+			fmt.Fprintf(w, "error while fetching logs: %s", err.Error())
 			return
 		}
 	}
 }
 
+// brWriter replaces new lines with <br/> html tag
 type brWriter struct {
 	writer io.Writer
 }

--- a/pkg/daemon/logs.go
+++ b/pkg/daemon/logs.go
@@ -2,9 +2,15 @@ package daemon
 
 import (
 	"encoding/json"
-	"github.com/testground/testground/pkg/api"
-	"github.com/testground/testground/pkg/rpc"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
+
+	"github.com/testground/testground/pkg/api"
+	"github.com/testground/testground/pkg/client"
+	"github.com/testground/testground/pkg/logging"
+	"github.com/testground/testground/pkg/rpc"
 )
 
 func (d *Daemon) logsHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
@@ -27,4 +33,52 @@ func (d *Daemon) logsHandler(engine api.Engine) func(w http.ResponseWriter, r *h
 
 		tgw.WriteResult(tsk)
 	}
+}
+
+func (d *Daemon) getLogsHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log := logging.S().With("req_id", r.Header.Get("X-Request-ID"))
+
+		log.Debugw("handle request", "command", "get logs")
+		defer log.Debugw("request handled", "command", "get logs")
+
+		w.Header().Set("Content-Type", "text/html")
+
+		taskId := r.URL.Query().Get("task_id")
+		if taskId == "" {
+			fmt.Fprintf(w, "url param `task_id` is missing")
+			return
+		}
+
+		req := api.LogsRequest{
+			TaskID: taskId,
+			Follow: false,
+		}
+
+		rr, ww := io.Pipe()
+
+		tgw := rpc.NewFileOutputWriter(ww)
+
+		go func() {
+			_, err := client.ParseLogsRequest(brWriter{w}, rr)
+			if err != nil {
+				fmt.Fprintf(w, "error while parsing logs", "err", err.Error())
+			}
+		}()
+
+		_, err := engine.Logs(r.Context(), req.TaskID, req.Follow, req.CancelWithContext, tgw)
+		if err != nil {
+			fmt.Fprintf(w, "error while fetching logs", "err", err.Error())
+			return
+		}
+	}
+}
+
+type brWriter struct {
+	writer io.Writer
+}
+
+func (b brWriter) Write(bb []byte) (n int, err error) {
+	replaced := strings.Replace(string(bb), "\n", "<br/>", -1)
+	return b.writer.Write([]byte(replaced))
 }

--- a/pkg/daemon/run.go
+++ b/pkg/daemon/run.go
@@ -3,12 +3,13 @@ package daemon
 import (
 	"errors"
 	"fmt"
-	"github.com/testground/testground/pkg/api"
-	"github.com/testground/testground/pkg/logging"
-	"github.com/testground/testground/pkg/rpc"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/testground/testground/pkg/api"
+	"github.com/testground/testground/pkg/logging"
+	"github.com/testground/testground/pkg/rpc"
 )
 
 func (d *Daemon) runHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/daemon/tasks.go
+++ b/pkg/daemon/tasks.go
@@ -55,9 +55,9 @@ func (d *Daemon) listTasksHandler(engine api.Engine) func(w http.ResponseWriter,
 
 		tf := "Mon Jan _2 15:04:05"
 
-		fmt.Fprintf(w, "<table><th>task id</th><th>type</th><th>state</th><th>created</th><th>updated</td><th>outputs tgz</th><th>stdout/stderr</th>")
+		fmt.Fprintf(w, "<table><th>task id</th><th>type</th><th>name</th><th>state</th><th>created</th><th>updated</td><th>outputs tgz</th><th>stdout/stderr</th>")
 		for _, t := range tasks {
-			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td><td>%v</td><td>%s</td><td><a href=/outputs?run_id=%s>download</a></td><td><a href=/logs?task_id=%s>stdout/stderr</a></td></tr>", t.ID, t.Type, t.State().State, t.Created().Format(tf), t.State().Created.Format(tf), t.ID, t.ID)
+			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%v</td><td>%s</td><td><a href=/outputs?run_id=%s>download</a></td><td><a href=/logs?task_id=%s>stdout/stderr</a></td></tr>", t.ID, t.Type, t.Name(), t.State().State, t.Created().Format(tf), t.State().Created.Format(tf), t.ID, t.ID)
 		}
 		fmt.Fprintf(w, "</table>")
 	}

--- a/pkg/daemon/tasks.go
+++ b/pkg/daemon/tasks.go
@@ -55,9 +55,9 @@ func (d *Daemon) listTasksHandler(engine api.Engine) func(w http.ResponseWriter,
 
 		tf := "Mon Jan _2 15:04:05"
 
-		fmt.Fprintf(w, "<table><th>task id</th><th>type</th><th>name</th><th>state</th><th>created</th><th>updated</td><th>outputs tgz</th><th>stdout/stderr</th>")
+		fmt.Fprintf(w, "<table><th>task id</th><th>type</th><th>name</th><th>state</th><th>created</th><th>updated</td><th>outputs tgz</th><th>stdout/stderr</th><th>took</th>")
 		for _, t := range tasks {
-			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%v</td><td>%s</td><td><a href=/outputs?run_id=%s>download</a></td><td><a href=/logs?task_id=%s>stdout/stderr</a></td></tr>", t.ID, t.Type, t.Name(), t.State().State, t.Created().Format(tf), t.State().Created.Format(tf), t.ID, t.ID)
+			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%v</td><td>%s</td><td><a href=/outputs?run_id=%s>download</a></td><td><a href=/logs?task_id=%s>stdout/stderr</a></td><td>%s</td></tr>", t.ID, t.Type, t.Name(), t.State().State, t.Created().Format(tf), t.State().Created.Format(tf), t.ID, t.ID, t.Took())
 		}
 		fmt.Fprintf(w, "</table>")
 	}

--- a/pkg/daemon/tasks.go
+++ b/pkg/daemon/tasks.go
@@ -53,9 +53,11 @@ func (d *Daemon) listTasksHandler(engine api.Engine) func(w http.ResponseWriter,
 			return
 		}
 
-		fmt.Fprintf(w, "<table><th>task id</th><th>type</th><th>state</th><th>created</th><th>updated</td><th>outputs zip</th><th>stdout/stderr</th>")
+		tf := "Mon Jan _2 15:04:05"
+
+		fmt.Fprintf(w, "<table><th>task id</th><th>type</th><th>state</th><th>created</th><th>updated</td><th>outputs tgz</th><th>stdout/stderr</th>")
 		for _, t := range tasks {
-			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td><td>%v</td><td>%s</td><td><a href=#>outputs zip</a></td><td><a href=/logs?task_id=%s>stdout/stderr</a></td></tr>", t.ID, t.Type, t.State().State, t.Created(), t.State().Created, t.ID)
+			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td><td>%v</td><td>%s</td><td><a href=/outputs?run_id=%s>download</a></td><td><a href=/logs?task_id=%s>stdout/stderr</a></td></tr>", t.ID, t.Type, t.State().State, t.Created().Format(tf), t.State().Created.Format(tf), t.ID, t.ID)
 		}
 		fmt.Fprintf(w, "</table>")
 	}

--- a/pkg/daemon/tasks.go
+++ b/pkg/daemon/tasks.go
@@ -55,9 +55,9 @@ func (d *Daemon) listTasksHandler(engine api.Engine) func(w http.ResponseWriter,
 
 		tf := "Mon Jan _2 15:04:05"
 
-		fmt.Fprintf(w, "<table><th>task id</th><th>type</th><th>name</th><th>state</th><th>created</th><th>updated</td><th>outputs tgz</th><th>stdout/stderr</th><th>took</th>")
+		fmt.Fprintf(w, "<table><th>task id</th><th>type</th><th>name</th><th>state</th><th>created</th><th>updated</td><th>outputs tgz</th><th>task logs</th><th>took</th>")
 		for _, t := range tasks {
-			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%v</td><td>%s</td><td><a href=/outputs?run_id=%s>download</a></td><td><a href=/logs?task_id=%s>stdout/stderr</a></td><td>%s</td></tr>", t.ID, t.Type, t.Name(), t.State().State, t.Created().Format(tf), t.State().Created.Format(tf), t.ID, t.ID, t.Took())
+			fmt.Fprintf(w, "<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td><td>%v</td><td>%s</td><td><a href=/outputs?run_id=%s>download</a></td><td><a href=/logs?task_id=%s>logs</a></td><td>%s</td></tr>", t.ID, t.Type, t.Name(), t.State().State, t.Created().Format(tf), t.State().Created.Format(tf), t.ID, t.ID, t.Took())
 		}
 		fmt.Fprintf(w, "</table>")
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -4,6 +4,12 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
 	"github.com/rs/xid"
 	"github.com/testground/testground/pkg/api"
 	"github.com/testground/testground/pkg/build"
@@ -11,11 +17,6 @@ import (
 	"github.com/testground/testground/pkg/rpc"
 	"github.com/testground/testground/pkg/runner"
 	"github.com/testground/testground/pkg/task"
-	"io"
-	"os"
-	"path/filepath"
-	"sync"
-	"time"
 )
 
 // AllBuilders enumerates all builders known to the system.
@@ -209,6 +210,8 @@ func (e *Engine) QueueRun(request *api.RunRequest, sources *api.UnpackedSources)
 	err := e.queue.Push(&task.Task{
 		Version:  0,
 		Priority: request.Priority,
+		Plan:     request.Composition.Global.Plan,
+		Case:     request.Composition.Global.Case,
 		ID:       id,
 		Type:     task.TypeRun,
 		Input: &RunInput{

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -330,15 +330,29 @@ func stringInSlice(a string, list []string) bool {
 }
 
 func (e *Engine) Tasks(filters api.TasksFilters) ([]task.Task, error) {
-	var res []task.Task
+	var (
+		res    []task.Task
+		before time.Time
+		after  time.Time
+	)
 
-	before := time.Now().UTC().Add(-24 * time.Hour)
-	after := time.Now().UTC()
+	if filters.Before != nil {
+		before = filters.Before.UTC()
+	} else {
+		before = time.Now().UTC().Add(-24 * time.Hour) // Last day
+	}
+
+	if filters.After != nil {
+		after = filters.After.UTC()
+	} else {
+		after = time.Now().UTC()
+	}
 
 	e.signalsLk.RLock()
 
 	for _, state := range filters.States {
 		var prefix string
+		var ires []task.Task
 
 		switch state {
 		case task.StateScheduled:
@@ -355,13 +369,23 @@ func (e *Engine) Tasks(filters api.TasksFilters) ([]task.Task, error) {
 		}
 
 		for _, tsk := range tsks {
+			if filters.TestPlan != "" && tsk.Plan != filters.TestPlan {
+				continue
+			}
+			
+			if filters.TestCase != "" && tsk.Case != filters.TestCase {
+				continue
+			}
+
 			for _, tp := range filters.Types {
 				if tsk.Type == tp {
-					res = append(res, *tsk)
+					ires = append([]task.Task{*tsk}, ires...)
 					break
 				}
 			}
 		}
+
+		res = append(res, ires...)
 	}
 
 	e.signalsLk.RUnlock()

--- a/pkg/engine/supervisor.go
+++ b/pkg/engine/supervisor.go
@@ -119,7 +119,7 @@ func (e *Engine) worker(n int) {
 }
 
 func (e *Engine) postStatusToSlack(taskId string, state task.State) error {
-	body := strings.NewReader(`{"text":"Task ` + taskId + ` completed: Check status at: https://protocol.ai/?id=` + taskId + ` !"}`)
+	body := strings.NewReader(`{"text":"Task ` + taskId + ` completed. Check status at: https://ci.testground.ipfs.team/tasks"}`)
 
 	cl := &http.Client{
 		Timeout: time.Second * 10,

--- a/pkg/engine/supervisor.go
+++ b/pkg/engine/supervisor.go
@@ -119,12 +119,12 @@ func (e *Engine) worker(n int) {
 }
 
 func (e *Engine) postStatusToSlack(taskId string, state task.State) error {
-	body := strings.NewReader(`{"text":"Task ` + taskId + ` completed. Check status at: https://ci.testground.ipfs.team/tasks"}`)
-
-	cl := &http.Client{
-		Timeout: time.Second * 10,
+	if e.envcfg.Daemon.SlackWebhookURL == "" {
+		return nil
 	}
 
+	cl := &http.Client{Timeout: time.Second * 10}
+	body := strings.NewReader(`{"text":"Task ` + taskId + ` completed. Check status at: https://ci.testground.ipfs.team/tasks"}`)
 	res, err := cl.Post(
 		e.envcfg.Daemon.SlackWebhookURL,
 		"application/json; charset=UTF-8",

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -26,7 +26,7 @@ var (
 
 func init() {
 	encConfig = zap.NewDevelopmentEncoderConfig()
-	encConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+	encConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	encConfig.EncodeCaller = nil
 	encConfig.EncodeTime = func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 		enc.AppendString(t.UTC().Format(time.StampMicro))

--- a/pkg/logging/log.go
+++ b/pkg/logging/log.go
@@ -26,7 +26,7 @@ var (
 
 func init() {
 	encConfig = zap.NewDevelopmentEncoderConfig()
-	encConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	encConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	encConfig.EncodeCaller = nil
 	encConfig.EncodeTime = func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 		enc.AppendString(t.UTC().Format(time.StampMicro))

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -67,6 +67,10 @@ func (t *Task) Name() string {
 	return t.Plan + ":" + t.Case
 }
 
+func (t *Task) Took() time.Duration {
+	return t.State().Created.Sub(t.Created()).Truncate(time.Second)
+}
+
 func (t *Task) State() DatedState {
 	if len(t.States) == 0 {
 		panic("task must have a state")

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -63,6 +63,10 @@ func (t *Task) Created() time.Time {
 	return t.States[0].Created
 }
 
+func (t *Task) Name() string {
+	return t.Plan + ":" + t.Case
+}
+
 func (t *Task) State() DatedState {
 	if len(t.States) == 0 {
 		panic("task must have a state")

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -45,8 +45,10 @@ type Result struct {
 // state of a running or scheduled task.
 type Task struct {
 	Version  int          `json:"version"`  // Schema version
-	Priority int          `json:"priority"` // scheduling priority
+	Priority int          `json:"priority"` // Scheduling priority
 	ID       string       `json:"id"`       // Unique identifier for this task
+	Plan     string       `json:"plan"`     // Test plan
+	Case     string       `json:"case"`     // Test case
 	States   []DatedState `json:"states"`   // State of the task
 	Type     Type         `json:"type"`     // Type of the task
 	Input    interface{}  `json:"input"`    // The input data for this task


### PR DESCRIPTION
This PR is:
1. Adding `SlackWebhookURL` to which we publish a message when a task is completed. We don't do anything if this field is empty.
2. Adds 3 GET endpoints:
```
/tasks - lists all tasks
/logs - used to fetch logs for a given task
/outputs - returns a download of the outputs tgz for a given task
```

TODO:
- [x] make slack notifications optional
- [x] add testplan/testcase in the message
- [x] fix `outputs` link on `tasks` html page
- [x] fix tests