### PR TITLE
add route to gateway, so that we dont blackhole it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	go.uber.org/zap v1.15.0
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
-	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
+	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
 	golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f // indirect
 	google.golang.org/grpc v1.29.1 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect

--- a/pkg/sidecar/k8s_reactor.go
+++ b/pkg/sidecar/k8s_reactor.go
@@ -32,7 +32,8 @@ import (
 const (
 	controlNetworkIfname = "eth0"
 	dataNetworkIfname    = "eth1"
-	podCidr              = "100.96.0.0/11"
+	podCIDR              = "100.96.0.0/11"
+	servicesCIDR         = "100.64.0.0/10"
 )
 
 var (
@@ -252,8 +253,8 @@ func (d *K8sReactor) manageContainer(ctx context.Context, container *docker.Cont
 
 		logging.S().Debugw("inspecting controlLink route", "route.Src", route.Src, "route.Dst", routeDst, "gw", route.Gw, "container", container.ID)
 
-		if route.Dst != nil && route.Dst.String() == podCidr {
-			logging.S().Debugw("marking for deletion podCidr dst route", "route.Src", route.Src, "route.Dst", routeDst, "gw", route.Gw, "container", container.ID)
+		if route.Dst != nil && route.Dst.String() == podCIDR {
+			logging.S().Debugw("marking for deletion podCIDR dst route", "route.Src", route.Src, "route.Dst", routeDst, "gw", route.Gw, "container", container.ID)
 			routesToBeDeleted = append(routesToBeDeleted, route)
 			continue
 		}
@@ -317,7 +318,7 @@ func (d *K8sReactor) manageContainer(ctx context.Context, container *docker.Cont
 
 		// detect the gateway => we know that we are going to delete the services CIDR, which are routed via the gateway,
 		// so we use they to figure out the gateway IP as well as the link index
-		if !addedGwRoute && routeDst == "100.64.0.0/10" {
+		if !addedGwRoute && routeDst == servicesCIDR {
 			addedGwRoute = true
 
 			logging.S().Infow("detecting gateway", "linkIndex", r.LinkIndex, "route.Src", r.Src, "route.Dst", routeDst, "gw", r.Gw, "container", container.ID)


### PR DESCRIPTION
This PR is explicitly adding a route to the gateway, because otherwise packets to DNS (and other services) are dropped:

```
/ # ip route
28.116.0.0/16 dev eth1 scope link  src 28.116.128.0 # data network
30.0.0.0 dev eth1 scope link # data network
blackhole 100.64.0.0/10 # we want to drop packets to the services CIDR apart from DNS
100.64.0.10 via 100.96.4.1 dev eth0 # this is DNS
100.96.1.9 via 100.96.4.1 dev eth0 # this is influxdb
100.96.3.3 via 100.96.4.1 dev eth0 # this is redis
blackhole 100.96.4.0/24 # we want to drop packets to all destinations at 100.96.4.x except 100.96.4.1
100.96.4.1 dev eth0 scope link # the route we are adding in this PR
```

---

This problem got triggered when upgrading Kubernetes, weave and flannel, as well as host OS from `debian 9 stretch` to `ubuntu` `Ubuntu 20.04.1 LTS` (kernel from `4.9.0-11-amd64` to `5.4.0-1028-aws`) at https://github.com/testground/infra/pull/64

I am not sure why packets going through 100.96.4.1 (i.e. the gateway) were not being dropped until now.