### PR TITLE
Fixed exec:go replace

### DIFF
--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -66,7 +66,7 @@ func (b *ExecGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.O
 	// If we have version overrides, apply them.
 	var replaces []string
 	for mod, ver := range in.Dependencies {
-		replaces = append(replaces, fmt.Sprintf("-replace=%s=%s@%s", mod, mod, ver))
+		replaces = append(replaces, fmt.Sprintf("-replace=%s=%s@%s", mod, ver.Target, ver.Version))
 	}
 
 	if sdksrc != "" {


### PR DESCRIPTION
* There was a minor bug when trying to replace dependencies with `exec:go`.