### PR TITLE
feat: support env vars in composition files

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
+	"text/template"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/testground/testground/pkg/api"
@@ -122,6 +126,10 @@ var RunCommand = cli.Command{
 	},
 }
 
+type compositionData struct {
+	Env map[string]string
+}
+
 func runCompositionCmd(c *cli.Context) (err error) {
 	comp := new(api.Composition)
 	file := c.String("file")
@@ -129,7 +137,31 @@ func runCompositionCmd(c *cli.Context) (err error) {
 		return fmt.Errorf("no composition file supplied")
 	}
 
-	if _, err = toml.DecodeFile(file, comp); err != nil {
+	fdata, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	data := &compositionData{Env: map[string]string{}}
+
+	// Build a map of environment variables
+	for _, v := range os.Environ() {
+		s := strings.SplitN(v, "=", 2)
+		data.Env[s[0]] = s[1]
+	}
+
+	// Parse and run the composition as a template
+	tpl, err := template.New("tpl").Parse(string(fdata))
+	if err != nil {
+		return err
+	}
+	buff := &bytes.Buffer{}
+	err = tpl.Execute(buff, data)
+	if err != nil {
+		return err
+	}
+
+	if _, err = toml.Decode(buff.String(), comp); err != nil {
 		return fmt.Errorf("failed to process composition file: %w", err)
 	}
 


### PR DESCRIPTION
Fixes #1197

I chose to go for the built-in Go templates to avoid more dependencies and they're more flexible in the long run.