### PR TITLE
testplan benchmarks: remove `all` testcase

### DIFF
--- a/plans/benchmarks/manifest.toml
+++ b/plans/benchmarks/manifest.toml
@@ -23,16 +23,6 @@ enabled = true
 enabled = true
 
 [[testcases]]
-name = "all"
-instances = { min = 1, max = 20000, default = 1 }
-
-  [testcases.params]
-  barrier_iterations = { type = "int", desc = "number of iterations of the barrier test", unit = "iteration", default = 10 }
-  subtree_iterations = { type = "int", desc = "number of iterations of the subtree test", unit = "iteration", default = 2000 }
-  subtree_test_timeout_secs  = { type = "int", desc = "subtree testcase timeout", unit = "seconds", default = 300 }
-  barrier_test_timeout_secs  = { type = "int", desc = "barrier testcase timeout", unit = "seconds", default = 300 }
-
-[[testcases]]
 name = "startup"
 instances = { min = 1, max = 20000, default = 1 }
 


### PR DESCRIPTION
This PR is removing the `all` test case from the manifest.toml of the sample `benchmarks` test plan, as there is no such test case, and this is confusing.

cc @shapnam83