### PR TITLE
add support for capturing profiles.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401
-	github.com/testground/sdk-go v0.2.8-0.20210303190707-df0775652638
+	github.com/testground/sdk-go v0.2.8-0.20210308104428-a3fce355bc6c
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/vishvananda/netlink v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/containerd/containerd v1.3.4 // indirect
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/containernetworking/cni v0.7.1
-	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.4.2-0.20200206084213-b5fc6ea92cde
 	github.com/docker/go-connections v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/containerd/containerd v1.3.4 // indirect
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/containernetworking/cni v0.7.1
+	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.4.2-0.20200206084213-b5fc6ea92cde
 	github.com/docker/go-connections v0.4.0
@@ -47,7 +48,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401
-	github.com/testground/sdk-go v0.2.6-0.20201016180515-1e40e1b0ec3a
+	github.com/testground/sdk-go v0.2.8-0.20210303190707-df0775652638
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/vishvananda/netlink v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -362,10 +362,6 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401 h1:h9FML1FUPWJgWXa5DxYYMgApb4UNYLw67/Qr0F7hdhY=
 github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401/go.mod h1:MT3F6oeXhaO0bwhclY7dbOxKVfuDuWuO9YHy+TZvgNc=
-github.com/testground/sdk-go v0.2.8-0.20210303182058-325f2c0777ab h1:5bdkos8zIv4Td/GzlEAHamTRcLNeLumaQtkxTMbO/SY=
-github.com/testground/sdk-go v0.2.8-0.20210303182058-325f2c0777ab/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
-github.com/testground/sdk-go v0.2.8-0.20210303190339-3bf897a8c1af h1:FUR3w8XkNyW/sZnOOLz5mE3hVbfrj9bVdqiaMQsqJkM=
-github.com/testground/sdk-go v0.2.8-0.20210303190339-3bf897a8c1af/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
 github.com/testground/sdk-go v0.2.8-0.20210303190707-df0775652638 h1:1r6J9hZVsY7l2jVNHkS7ctb8s0zteSTBrUX7ZZcBNbA=
 github.com/testground/sdk-go v0.2.8-0.20210303190707-df0775652638/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401 h1:h9FML1FUPWJgWXa5DxYYMgApb4UNYLw67/Qr0F7hdhY=
 github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401/go.mod h1:MT3F6oeXhaO0bwhclY7dbOxKVfuDuWuO9YHy+TZvgNc=
-github.com/testground/sdk-go v0.2.8-0.20210303190707-df0775652638 h1:1r6J9hZVsY7l2jVNHkS7ctb8s0zteSTBrUX7ZZcBNbA=
-github.com/testground/sdk-go v0.2.8-0.20210303190707-df0775652638/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
+github.com/testground/sdk-go v0.2.8-0.20210308104428-a3fce355bc6c h1:LK94XuMCfllVc0MXlCQXQ92n1sCAD6c5F+pR4+r3vWs=
+github.com/testground/sdk-go v0.2.8-0.20210308104428-a3fce355bc6c/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/raulk/clock v1.1.0/go.mod h1:3MpVxdZ/ODBQDxbN+kzshf5OSZwPjtMDx6BBXBmOeY0=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -361,8 +362,12 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401 h1:h9FML1FUPWJgWXa5DxYYMgApb4UNYLw67/Qr0F7hdhY=
 github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401/go.mod h1:MT3F6oeXhaO0bwhclY7dbOxKVfuDuWuO9YHy+TZvgNc=
-github.com/testground/sdk-go v0.2.6-0.20201016180515-1e40e1b0ec3a h1:iQDLQpTGtdfatdQtGqQBuoXFrl2AQ0n3Q8mNKkqbmnw=
-github.com/testground/sdk-go v0.2.6-0.20201016180515-1e40e1b0ec3a/go.mod h1:Q4dnWsUBH+dZ1u7aEGDBHWGUaLfhitjUq3UJQqxeTmk=
+github.com/testground/sdk-go v0.2.8-0.20210303182058-325f2c0777ab h1:5bdkos8zIv4Td/GzlEAHamTRcLNeLumaQtkxTMbO/SY=
+github.com/testground/sdk-go v0.2.8-0.20210303182058-325f2c0777ab/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
+github.com/testground/sdk-go v0.2.8-0.20210303190339-3bf897a8c1af h1:FUR3w8XkNyW/sZnOOLz5mE3hVbfrj9bVdqiaMQsqJkM=
+github.com/testground/sdk-go v0.2.8-0.20210303190339-3bf897a8c1af/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
+github.com/testground/sdk-go v0.2.8-0.20210303190707-df0775652638 h1:1r6J9hZVsY7l2jVNHkS7ctb8s0zteSTBrUX7ZZcBNbA=
+github.com/testground/sdk-go v0.2.8-0.20210303190707-df0775652638/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/pkg/api/composition.go
+++ b/pkg/api/composition.go
@@ -381,15 +381,19 @@ func (c Composition) PrepareForRun(manifest *TestPlanManifest) (*Composition, er
 			}
 
 			trickleMap := func(from, to map[string]string) (result map[string]string) {
-				// copy all params in to.
-				result = make(map[string]string, len(from))
-				for k, v := range from {
-					result[k] = v
-				}
-				// iterate over all global params, and copy over those that haven't been overridden.
-				for k, v := range from {
-					if _, present := to[k]; !present {
+				if to == nil {
+					// copy all params in to.
+					result = make(map[string]string, len(from))
+					for k, v := range from {
 						result[k] = v
+					}
+				} else {
+					result = to
+					// iterate over all global params, and copy over those that haven't been overridden.
+					for k, v := range from {
+						if _, present := to[k]; !present {
+							result[k] = v
+						}
 					}
 				}
 				return result

--- a/pkg/api/composition.go
+++ b/pkg/api/composition.go
@@ -202,6 +202,17 @@ type Run struct {
 	// TestParams specify the test parameters to pass down to instances of this
 	// group.
 	TestParams map[string]string `toml:"test_params" json:"test_params"`
+
+	// Profiles specifies the profiles to capture, and the frequency of capture
+	// of each. Profile support is SDK-dependent, as it relies entirely on the
+	// facilities provided by the language runtime.
+	//
+	// In the case of Go, all profile kinds listed in https://golang.org/pkg/runtime/pprof/#Profile
+	// are supported, taking a frequency expressed in time.Duration string
+	// representation (e.g. 5s for every five seconds). Additionally, a special
+	// profile kind "cpu" is supported; it takes no frequency and it starts a
+	// CPU profile for the entire duration of the test.
+	Profiles map[string]string `toml:"profiles" json:"profiles"`
 }
 
 type Dependency struct {
@@ -369,24 +380,23 @@ func (c Composition) PrepareForRun(manifest *TestPlanManifest) (*Composition, er
 				grp.Run.Artifact = def.Artifact
 			}
 
-			// If we have default parameters to set, handle the case where
-			// the group map is uninitialized by copying over all defaults,
-			// as well as the case where we have to merge.
-			if len(def.TestParams) > 0 {
-				if grp.Run.TestParams == nil {
-					grp.Run.TestParams = make(map[string]string, len(def.TestParams))
-					for k, v := range def.TestParams {
-						grp.Run.TestParams[k] = v
-					}
-				} else {
-					// Test params.
-					for k, v := range def.TestParams {
-						if _, present := grp.Run.TestParams[k]; !present {
-							grp.Run.TestParams[k] = v
-						}
+			trickleMap := func(from, to map[string]string) (result map[string]string) {
+				// copy all params in to.
+				result = make(map[string]string, len(from))
+				for k, v := range from {
+					result[k] = v
+				}
+				// iterate over all global params, and copy over those that haven't been overridden.
+				for k, v := range from {
+					if _, present := to[k]; !present {
+						result[k] = v
 					}
 				}
+				return result
 			}
+
+			grp.Run.TestParams = trickleMap(def.TestParams, grp.Run.TestParams)
+			grp.Run.Profiles = trickleMap(def.Profiles, grp.Run.Profiles)
 		}
 	}
 

--- a/pkg/api/runner.go
+++ b/pkg/api/runner.go
@@ -75,6 +75,10 @@ type RunGroup struct {
 
 	// Parameters are the runtime parameters to the test case.
 	Parameters map[string]string
+
+	// Profiles specifies the profiles to capture. Refer to the docs
+	// on Run#Profiles for more info.
+	Profiles map[string]string
 }
 
 type RunOutput struct {

--- a/pkg/cmd/tasks.go
+++ b/pkg/cmd/tasks.go
@@ -15,7 +15,7 @@ var TasksCommand = cli.Command{
 	Name:   "tasks",
 	Usage:  "get a list of the existing tasks",
 	Action: tasksCommand,
-	Flags: []cli.Flag{
+	Flags:  []cli.Flag{
 		// TODO(hac): add filters (type of task, date, state, etc)
 	},
 }

--- a/pkg/engine/supervisor.go
+++ b/pkg/engine/supervisor.go
@@ -562,6 +562,7 @@ func (e *Engine) doRun(ctx context.Context, id string, input *RunInput, ow *rpc.
 			ArtifactPath: grp.Run.Artifact,
 			Parameters:   grp.Run.TestParams,
 			Resources:    grp.Resources,
+			Profiles:     grp.Run.Profiles,
 		}
 
 		in.Groups = append(in.Groups, g)

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -294,6 +294,7 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 		runenv.TestGroupID = g.ID
 		runenv.TestGroupInstanceCount = g.Instances
 		runenv.TestInstanceParams = g.Parameters
+		runenv.TestCaptureProfiles = g.Profiles
 
 		result.Outcomes[g.ID] = &GroupOutcome{
 			Total: g.Instances,

--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -195,6 +195,7 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 		runenv.TestGroupID = g.ID
 		runenv.TestGroupInstanceCount = g.Instances
 		runenv.TestInstanceParams = g.Parameters
+		runenv.TestCaptureProfiles = g.Profiles
 
 		// Serialize the runenv into env variables to pass to docker.
 		env := conv.ToOptionsSlice(runenv.ToEnvVars())

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -275,6 +275,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		runenv.TestGroupInstanceCount = g.Instances
 		runenv.TestGroupID = g.ID
 		runenv.TestInstanceParams = g.Parameters
+		runenv.TestCaptureProfiles = g.Profiles
 
 		result.Outcomes[g.ID] = &GroupOutcome{
 			Total: g.Instances,

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -121,6 +121,7 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 			runenv.TestInstanceParams = g.Parameters
 			runenv.TestOutputsPath = odir
 			runenv.TestStartTime = time.Now()
+			runenv.TestCaptureProfiles = g.Profiles
 
 			env := conv.ToOptionsSlice(runenv.ToEnvVars())
 			env = append(env, "INFLUXDB_URL=http://localhost:8086")

--- a/pkg/sidecar/docker_links.go
+++ b/pkg/sidecar/docker_links.go
@@ -10,7 +10,6 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-
 type link struct {
 	netlink.Link
 	IPv4, IPv6 *net.IPNet


### PR DESCRIPTION
This PR introduces the ability to tell test plans to capture system profiles automatically.

For support on the Go SDK, check out this PR: https://github.com/testground/sdk-go/pull/38

There is now a new `profiles` field in `run` parameters, that can be set globally, or per-group:

```toml
[global]
  plan = "libp2p/ping"
  case = "ping"
  total_instances = 10
  builder = "docker:go"
  runner = "local:docker"

  [global.run]
  profiles = { cpu = "", heap = "5s", allocs = "10s" }
```

It takes a map of string => string, where the key is the profile type, and the value is the frequency (in Go `time.Duration` string representation, e.g. `5s`, `1m`).

For Go test plans:

* `cpu` => starts a CPU profile for the entire duration of the test job; the value is ignored.
* any other type listed in the godocs for the `runtime/pprof` package: https://golang.org/pkg/runtime/pprof/#Profile

The profiles will be written in the outputs directory, and will be available with `testground collect`.

![image](https://user-images.githubusercontent.com/1101242/109859874-5f6d6000-7c55-11eb-9688-cd576a8c5398.png)

## TODO

- [ ] release sdk-go.