### PR TITLE
add support for temp directories to local:exec and local:docker runners.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401
-	github.com/testground/sdk-go v0.2.8-0.20210308104428-a3fce355bc6c
+	github.com/testground/sdk-go v0.2.8-0.20210319194830-4c62042da4c3
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/vishvananda/netlink v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401
-	github.com/testground/sdk-go v0.2.8-0.20210319194830-4c62042da4c3
+	github.com/testground/sdk-go v0.2.8-0.20210322095044-e00c1b9d2006
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/vishvananda/netlink v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401 h1:h9FML1FUPWJgWXa5DxYYMgApb4UNYLw67/Qr0F7hdhY=
 github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401/go.mod h1:MT3F6oeXhaO0bwhclY7dbOxKVfuDuWuO9YHy+TZvgNc=
-github.com/testground/sdk-go v0.2.8-0.20210319194830-4c62042da4c3 h1:O1PD+N7y27XOnp2vh1TwNAE7ZTsyn+UBOQmLQq6hpVg=
-github.com/testground/sdk-go v0.2.8-0.20210319194830-4c62042da4c3/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
+github.com/testground/sdk-go v0.2.8-0.20210322095044-e00c1b9d2006 h1:6CNrSkJdL/lgTX4T6Luv87UoVUI62HnYIY41zfrVJcA=
+github.com/testground/sdk-go v0.2.8-0.20210322095044-e00c1b9d2006/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/go.sum
+++ b/go.sum
@@ -362,8 +362,8 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401 h1:h9FML1FUPWJgWXa5DxYYMgApb4UNYLw67/Qr0F7hdhY=
 github.com/testground/plan-templates/templates v0.0.0-20200429051153-b24fdc73e401/go.mod h1:MT3F6oeXhaO0bwhclY7dbOxKVfuDuWuO9YHy+TZvgNc=
-github.com/testground/sdk-go v0.2.8-0.20210308104428-a3fce355bc6c h1:LK94XuMCfllVc0MXlCQXQ92n1sCAD6c5F+pR4+r3vWs=
-github.com/testground/sdk-go v0.2.8-0.20210308104428-a3fce355bc6c/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
+github.com/testground/sdk-go v0.2.8-0.20210319194830-4c62042da4c3 h1:O1PD+N7y27XOnp2vh1TwNAE7ZTsyn+UBOQmLQq6hpVg=
+github.com/testground/sdk-go v0.2.8-0.20210319194830-4c62042da4c3/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -240,6 +241,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		TestInstanceCount: input.TotalInstances,
 		TestSidecar:       true,
 		TestOutputsPath:   "/outputs",
+		TestTempPath:      "/temp", // not using /tmp to avoid overriding linux standard paths.
 		TestStartTime:     time.Now(),
 	}
 
@@ -269,7 +271,10 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		groupIdx    int
 	}
 
-	var containers []testContainer
+	var (
+		containers []testContainer
+		tmpdirs    []string
+	)
 	for _, g := range input.Groups {
 		runenv := template
 		runenv.TestGroupInstanceCount = g.Instances
@@ -306,6 +311,16 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 				break
 			}
 
+			// temporary directory.
+			var tmpdir string
+			tmpdir, err = ioutil.TempDir("", "testground")
+			if err != nil {
+				err = fmt.Errorf("failed to create temp dir: %s: %w", tmpdir, err)
+				break
+			}
+
+			tmpdirs = append(tmpdirs, tmpdir)
+
 			name := fmt.Sprintf("tg-%s-%s-%s-%s-%d", input.TestPlan, input.TestCase, input.RunID, g.ID, i)
 			log.Infow("creating container", "name", name)
 
@@ -329,6 +344,10 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 					Type:   mount.TypeBind,
 					Source: odir,
 					Target: runenv.TestOutputsPath,
+				}, {
+					Type:   mount.TypeBind,
+					Source: tmpdir,
+					Target: runenv.TestTempPath,
 				}},
 			}
 
@@ -518,6 +537,11 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		}
 	case <-ctx.Done():
 		err = ctx.Err()
+	}
+
+	// remove all temporary directories.
+	for _, tmpdir := range tmpdirs {
+		_ = os.RemoveAll(tmpdir)
 	}
 
 	return

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/testground/sdk-go/ptypes"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -100,7 +101,10 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 		_ = pretty.Wait()
 	}()
 
-	var total int
+	var (
+		total   int
+		tmpdirs []string
+	)
 	for _, g := range input.Groups {
 		reviewResources(g, ow)
 
@@ -115,11 +119,21 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 				continue
 			}
 
+			tmpdir, err := ioutil.TempDir("", "testground")
+			if err != nil {
+				err = fmt.Errorf("failed to create temp dir: %s: %w", tmpdir, err)
+				pretty.FailStart(tag, err)
+				continue
+			}
+
+			tmpdirs = append(tmpdirs, tmpdir)
+
 			runenv := template
 			runenv.TestGroupID = g.ID
 			runenv.TestGroupInstanceCount = g.Instances
 			runenv.TestInstanceParams = g.Parameters
 			runenv.TestOutputsPath = odir
+			runenv.TestTempPath = tmpdir
 			runenv.TestStartTime = time.Now()
 			runenv.TestCaptureProfiles = g.Profiles
 
@@ -149,6 +163,11 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 
 	if err := <-pretty.Wait(); err != nil {
 		return nil, err
+	}
+
+	// remove all temporary directories.
+	for _, tmpdir := range tmpdirs {
+		_ = os.RemoveAll(tmpdir)
 	}
 
 	return &api.RunOutput{RunID: input.RunID}, nil


### PR DESCRIPTION
A temporary directory is created per instance on the host's file system.

It is then injected into the test instance via the `TEST_TEMP_PATH` directory.

After the run finishes, the runner cleans up all temporary directories.

Use this to generate large random files, instantiate databases, etc.

Go SDK support: https://github.com/testground/sdk-go/pull/39

---

TODO for a future PR:

- Support in `cluster:k8s` runner.