### PR TITLE
feat: emit periodic goroutine dumps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/testground/plan-templates v1.0.3
-	github.com/testground/sdk-go v0.2.8-0.20210522074938-6aa84502788f
+	github.com/testground/sdk-go v0.2.8-0.20210527111726-b1de9869438c
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/vishvananda/netlink v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/testground/plan-templates v1.0.3
-	github.com/testground/sdk-go v0.2.8-0.20210322095044-e00c1b9d2006
+	github.com/testground/sdk-go v0.2.8-0.20210522074938-6aa84502788f
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/vishvananda/netlink v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -358,8 +358,8 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/testground/plan-templates v1.0.3 h1:+S/qnWxo8RbHVwvuiaBxK+3vDQHLthHh8CogYOyOI7E=
 github.com/testground/plan-templates v1.0.3/go.mod h1:3/nho09HxOlLSNlSBIlMk5InyzXula/uvTsuJXDZw5A=
-github.com/testground/sdk-go v0.2.8-0.20210322095044-e00c1b9d2006 h1:6CNrSkJdL/lgTX4T6Luv87UoVUI62HnYIY41zfrVJcA=
-github.com/testground/sdk-go v0.2.8-0.20210322095044-e00c1b9d2006/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
+github.com/testground/sdk-go v0.2.8-0.20210522074938-6aa84502788f h1:x19s2Xm8xWE/d97CQljxVqWuN5m+xgmn46vljNo85hw=
+github.com/testground/sdk-go v0.2.8-0.20210522074938-6aa84502788f/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/go.sum
+++ b/go.sum
@@ -358,8 +358,8 @@ github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFd
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/testground/plan-templates v1.0.3 h1:+S/qnWxo8RbHVwvuiaBxK+3vDQHLthHh8CogYOyOI7E=
 github.com/testground/plan-templates v1.0.3/go.mod h1:3/nho09HxOlLSNlSBIlMk5InyzXula/uvTsuJXDZw5A=
-github.com/testground/sdk-go v0.2.8-0.20210522074938-6aa84502788f h1:x19s2Xm8xWE/d97CQljxVqWuN5m+xgmn46vljNo85hw=
-github.com/testground/sdk-go v0.2.8-0.20210522074938-6aa84502788f/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
+github.com/testground/sdk-go v0.2.8-0.20210527111726-b1de9869438c h1:wGNb9wgB9jJZV26YcdqK3yEyPAAgRZ3Dl9FHon3Np+c=
+github.com/testground/sdk-go v0.2.8-0.20210527111726-b1de9869438c/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/pkg/api/composition.go
+++ b/pkg/api/composition.go
@@ -74,6 +74,10 @@ type Global struct {
 	// test parameters or build artifacts. Groups can override these in their
 	// local run definition.
 	Run *Run `toml:"run" json:"run"`
+
+	// EmitDumps specifies the frequency (in seconds) to emit goroutine dumps in a
+	// test instance. 0 (default) is disabled.
+	EmitDumps int `toml:"emit_dumps" json:"emit_dumps"`
 }
 
 type Metadata struct {

--- a/pkg/api/runner.go
+++ b/pkg/api/runner.go
@@ -57,6 +57,9 @@ type RunInput struct {
 
 	// Groups enumerates the groups participating in this run.
 	Groups []*RunGroup
+
+	// EmitDumps is the frequency (in seconds) to emit goroutine dumps.
+	EmitDumps int
 }
 
 type RunGroup struct {

--- a/pkg/engine/supervisor.go
+++ b/pkg/engine/supervisor.go
@@ -552,6 +552,7 @@ func (e *Engine) doRun(ctx context.Context, id string, input *RunInput, ow *rpc.
 		TestCase:       clean(tcase),
 		TotalInstances: int(comp.Global.TotalInstances),
 		Groups:         make([]*api.RunGroup, 0, len(comp.Groups)),
+		EmitDumps:      comp.Global.EmitDumps,
 	}
 
 	// Trigger a build for each group, and wait until all of them are done.

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -240,6 +240,7 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 		TestSidecar:       true,
 		TestOutputsPath:   "/outputs",
 		TestStartTime:     time.Now(),
+		TestEmitDumps:     input.EmitDumps,
 	}
 
 	// currently weave is not releaasing IP addresses upon container deletion - we get errors back when trying to

--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -88,6 +88,7 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 		TestRun:           input.RunID,
 		TestInstanceCount: input.TotalInstances,
 		TestSidecar:       true,
+		TestEmitDumps:     input.EmitDumps,
 	}
 
 	// Create a docker client.

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -242,6 +242,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		TestOutputsPath:   "/outputs",
 		TestTempPath:      "/temp", // not using /tmp to avoid overriding linux standard paths.
 		TestStartTime:     time.Now(),
+		TestEmitDumps:     input.EmitDumps,
 	}
 
 	// Create a data network.

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -86,6 +86,7 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 		TestInstanceCount: input.TotalInstances,
 		TestSidecar:       false,
 		TestSubnet:        &ptypes.IPNet{IPNet: *localSubnet},
+		TestEmitDumps:     input.EmitDumps,
 	}
 
 	// Spawn as many instances as the input parameters require.


### PR DESCRIPTION
Fixes #1232.

Depends on https://github.com/testground/sdk-go/pull/41.

Composition example:

```toml
[metadata]
name    = "test"
author  = "test"

[global]
plan    = "network"
case    = "ping-pong"
builder = "docker:go"
runner  = "local:docker"
emit_dumps = 5
total_instances = 2

[global.build_config]
go_version = "1.16"

[[groups]]
id = "all"
instances = { count = 2 }
```

Emits goroutine dumps every 5 seconds on each test instance. Plan `network` needs to be upgraded to SDK in linked PR in order for this to work.