### PR TITLE
fix: return error instead of panicking

### DIFF
--- a/pkg/task/storage_test.go
+++ b/pkg/task/storage_test.go
@@ -11,8 +11,14 @@ import (
 
 func TestChangePrefix(t *testing.T) {
 	id := "bt4brhjpc98qra498sg0"
-	nexp := taskKey(prefixScheduled, id)
-	exp := taskKey(prefixProcessing, id)
+	nexp, err := taskKey(prefixScheduled, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exp, err := taskKey(prefixProcessing, id)
+	if err != nil {
+		t.Fatal(err)
+	}
 	inmem := storage.NewMemStorage()
 	db, err := leveldb.Open(inmem, nil)
 	if err != nil {


### PR DESCRIPTION
Fix panic "task key must be a xid id" by returning error instead.

Fixes #1241.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>