### PR TITLE
fix: macOS CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
           name: "install go on macOS"
           command: |
             brew --version
-            [ ! -d /usr/local/opt/go@1.16 ] && brew update && brew install go@1.16 && echo "done installing go"
+            [ ! -d /usr/local/opt/go@1.16 ] && brew install go@1.16 && echo "done installing go"
             echo 'export GOPATH="$HOME/go"' >> $BASH_ENV
             echo 'export PATH="/usr/local/opt/go@1.16/bin:$GOPATH/bin:$PATH"' >> $BASH_ENV
             source $BASH_ENV


### PR DESCRIPTION
Homebrew got updated on Circle CI and the new version does a shallow git clone by default so `brew update` fails. I simply removed that step as the newest version of Go should be available without needing to update brew.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>