### PR TITLE
fix: enable Redis on k8s test

### DIFF
--- a/integration_tests/01_k8s_kind_placebo_ok.sh
+++ b/integration_tests/01_k8s_kind_placebo_ok.sh
@@ -14,6 +14,7 @@ docker tag $ARTIFACT testplan:placebo
 kind load docker-image testplan:placebo
 
 pushd $TEMPDIR
+# enable redis using the docker healthcheck on the first k8s integration test
 testground healthcheck --runner local:docker --fix
 export REDIS_HOST=localhost
 testground run single --runner cluster:k8s --builder docker:go --use-build testplan:placebo --instances 1 --plan placebo --testcase ok --collect --wait | tee run.out

--- a/integration_tests/01_k8s_kind_placebo_ok.sh
+++ b/integration_tests/01_k8s_kind_placebo_ok.sh
@@ -14,6 +14,7 @@ docker tag $ARTIFACT testplan:placebo
 kind load docker-image testplan:placebo
 
 pushd $TEMPDIR
+testground healthcheck --runner local:docker --fix
 export REDIS_HOST=localhost
 testground run single --runner cluster:k8s --builder docker:go --use-build testplan:placebo --instances 1 --plan placebo --testcase ok --collect --wait | tee run.out
 RUNID=$(awk '/finished run with ID/ { print $9 }' run.out)


### PR DESCRIPTION
Enables Redis using the docker healthcheck on the first k8s integration test. Something similar is already being done on the second test. However, the first one was silently failing to connect to Redis.