### PR TITLE
feat: optionally disable influxdb batching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.0
 	github.com/testground/plan-templates v1.0.3
-	github.com/testground/sdk-go v0.2.8-0.20210322095044-e00c1b9d2006
+	github.com/testground/sdk-go v0.2.8-0.20210722082052-06492f073b2b
 	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/vishvananda/netlink v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -360,6 +360,8 @@ github.com/testground/plan-templates v1.0.3 h1:+S/qnWxo8RbHVwvuiaBxK+3vDQHLthHh8
 github.com/testground/plan-templates v1.0.3/go.mod h1:3/nho09HxOlLSNlSBIlMk5InyzXula/uvTsuJXDZw5A=
 github.com/testground/sdk-go v0.2.8-0.20210322095044-e00c1b9d2006 h1:6CNrSkJdL/lgTX4T6Luv87UoVUI62HnYIY41zfrVJcA=
 github.com/testground/sdk-go v0.2.8-0.20210322095044-e00c1b9d2006/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
+github.com/testground/sdk-go v0.2.8-0.20210722082052-06492f073b2b h1:OhapmIWCyhSWRs4KhAvG+dpvFX8kFLCvghMt2MZi+So=
+github.com/testground/sdk-go v0.2.8-0.20210722082052-06492f073b2b/go.mod h1:Y2Us+KUYioFgyzJXHLEdene+GCs40qQ4TtzP5z9nGAE=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/pkg/api/composition.go
+++ b/pkg/api/composition.go
@@ -74,6 +74,9 @@ type Global struct {
 	// test parameters or build artifacts. Groups can override these in their
 	// local run definition.
 	Run *Run `toml:"run" json:"run"`
+
+	// DisableInflux is used to disable InfluxDB batching.
+	DisableInflux bool `toml:"disable_influx" json:"disable_influx"`
 }
 
 type Metadata struct {

--- a/pkg/api/runner.go
+++ b/pkg/api/runner.go
@@ -55,6 +55,9 @@ type RunInput struct {
 	// TotalInstances is the total number of instances participating in this test case.
 	TotalInstances int
 
+	// DisableInflux disables InfluxDB batching.
+	DisableInflux bool
+
 	// Groups enumerates the groups participating in this run.
 	Groups []*RunGroup
 }

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -36,13 +36,14 @@ func setupClient(c *cli.Context) (*client.Client, *config.EnvConfig, error) {
 func createSingletonComposition(c *cli.Context) (*api.Composition, error) {
 	var (
 		// Global struct
-		plan      = c.String("plan")
-		testcase  = c.String("testcase")
-		instances = c.Uint("instances")
-		builder   = c.String("builder")
-		buildcfg  = c.StringSlice("build-cfg")
-		runner    = c.String("runner")
-		runcfg    = c.StringSlice("run-cfg")
+		plan          = c.String("plan")
+		testcase      = c.String("testcase")
+		instances     = c.Uint("instances")
+		builder       = c.String("builder")
+		buildcfg      = c.StringSlice("build-cfg")
+		runner        = c.String("runner")
+		runcfg        = c.StringSlice("run-cfg")
+		disableInflux = c.Bool("disable-influx")
 
 		// Build struct
 		dependencies = c.StringSlice("dep")
@@ -59,6 +60,7 @@ func createSingletonComposition(c *cli.Context) (*api.Composition, error) {
 			Builder:        builder,
 			Runner:         runner,
 			TotalInstances: instances,
+			DisableInflux:  disableInflux,
 		},
 		Groups: []*api.Group{
 			{

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -121,6 +121,10 @@ var RunCommand = cli.Command{
 					Name:  "metadata-commit",
 					Usage: "commit that triggered this run",
 				},
+				&cli.BoolFlag{
+					Name:  "disable-influx",
+					Usage: "disable InfluxDB batching",
+				},
 			),
 		},
 	},

--- a/pkg/engine/supervisor.go
+++ b/pkg/engine/supervisor.go
@@ -552,6 +552,7 @@ func (e *Engine) doRun(ctx context.Context, id string, input *RunInput, ow *rpc.
 		TestCase:       clean(tcase),
 		TotalInstances: int(comp.Global.TotalInstances),
 		Groups:         make([]*api.RunGroup, 0, len(comp.Groups)),
+		DisableInflux:  comp.Global.DisableInflux,
 	}
 
 	// Trigger a build for each group, and wait until all of them are done.

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -241,6 +241,7 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 		TestCase:          input.TestCase,
 		TestRun:           input.RunID,
 		TestInstanceCount: input.TotalInstances,
+		TestDisableInflux: input.DisableInflux,
 		TestSidecar:       true,
 		TestOutputsPath:   "/outputs",
 		TestStartTime:     time.Now(),

--- a/pkg/runner/cluster_swarm.go
+++ b/pkg/runner/cluster_swarm.go
@@ -87,6 +87,7 @@ func (*ClusterSwarmRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 		TestCase:          input.TestCase,
 		TestRun:           input.RunID,
 		TestInstanceCount: input.TotalInstances,
+		TestDisableInflux: input.DisableInflux,
 		TestSidecar:       true,
 	}
 

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -238,6 +238,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		TestCase:          input.TestCase,
 		TestRun:           input.RunID,
 		TestInstanceCount: input.TotalInstances,
+		TestDisableInflux: input.DisableInflux,
 		TestSidecar:       true,
 		TestOutputsPath:   "/outputs",
 		TestTempPath:      "/temp", // not using /tmp to avoid overriding linux standard paths.

--- a/pkg/runner/local_exec.go
+++ b/pkg/runner/local_exec.go
@@ -84,6 +84,7 @@ func (r *LocalExecutableRunner) Run(ctx context.Context, input *api.RunInput, ow
 		TestCase:          input.TestCase,
 		TestRun:           input.RunID,
 		TestInstanceCount: input.TotalInstances,
+		TestDisableInflux: input.DisableInflux,
 		TestSidecar:       false,
 		TestSubnet:        &ptypes.IPNet{IPNet: *localSubnet},
 	}


### PR DESCRIPTION
This PR fixes #1188 by adding an option `disable_influx` to the global section of compositions. For single runs, the flag `--disable-influx` can also be used. This option disables the InfluxDB metrics' pushing for tests that are using the updated version of the SDK.

`.out` files are still created.

- [ ] https://github.com/testground/sdk-go/pull/44 must be merged first and the version updated here.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>