### PR TITLE
fix: extra_sources builder reference

### DIFF
--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -207,8 +208,9 @@ func doBuild(c *cli.Context, comp *api.Composition) error {
 
 	// if there are extra sources to include for this builder, contextualize
 	// them to the plan's dir.
-	builder := comp.Global.Builder
+	builder := strings.Replace(comp.Global.Builder, ":", "_", -1)
 	extra := manifest.ExtraSources[builder]
+	logging.S().Infof("build %s extra %s", builder, extra)
 	for i, dir := range extra {
 		if !filepath.IsAbs(dir) {
 			// follow any symlinks in the plan dir.

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -226,10 +226,9 @@ func run(c *cli.Context, comp *api.Composition) (err error) {
 			}
 			logging.S().Infof("linking with sdk at: %s", sdkDir)
 		}
-
 		// if there are extra sources to include for this builder, contextualize
 		// them to the plan's dir.
-		builder := comp.Global.Builder
+		builder := strings.Replace(comp.Global.Builder, ":", "_", -1)
 		extraSrcs = manifest.ExtraSources[builder]
 		for i, dir := range extraSrcs {
 			if !filepath.IsAbs(dir) {

--- a/pkg/daemon/build.go
+++ b/pkg/daemon/build.go
@@ -4,10 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/mholt/archiver"
-	"github.com/testground/testground/pkg/api"
-	"github.com/testground/testground/pkg/logging"
-	"github.com/testground/testground/pkg/rpc"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -15,6 +11,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/mholt/archiver"
+	"github.com/testground/testground/pkg/api"
+	"github.com/testground/testground/pkg/logging"
+	"github.com/testground/testground/pkg/rpc"
 )
 
 func (d *Daemon) buildHandler(engine api.Engine) func(w http.ResponseWriter, r *http.Request) {
@@ -149,6 +150,7 @@ Outer:
 			if err := os.Mkdir(destdir, 0755); err != nil {
 				return nil, fmt.Errorf("failed to create directory for sdk: %w", err)
 			}
+			logging.S().Infof("extracting %s to %s", filename, destdir)
 			if err := archiver.NewZip().Unarchive(targetzip.Name(), destdir); err != nil {
 				return nil, fmt.Errorf("failed to decompress sdk: %w", err)
 			}


### PR DESCRIPTION
extra_sources wasn't working for me and when I dug deeper I found out there was a missing conversion. The builder had to be changed from `docker:generic` to `docker_generic` .