### PR TITLE
fix: do not change read-only non-namespaced sysctl

### DIFF
--- a/pkg/runner/local_common.go
+++ b/pkg/runner/local_common.go
@@ -63,8 +63,7 @@ func localCommonHealthcheck(ctx context.Context, hh *healthcheck.Helper, cli *cl
 					},
 				},
 				Sysctls: map[string]string{
-					"net.core.somaxconn":             "150000",
-					"net.netfilter.nf_conntrack_max": "120000",
+					"net.core.somaxconn": "150000",
 				},
 				RestartPolicy: container.RestartPolicy{
 					Name: "unless-stopped",


### PR DESCRIPTION
Fixes #1230.

**After merge:** add to docs the necessity to change this sysctl on the host system (eg [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.1/docker.html#docker-cli-run-prod-mode)).

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>