### PR TITLE
fix: delete another nf_conntrack_max

### DIFF
--- a/pkg/runner/local_common.go
+++ b/pkg/runner/local_common.go
@@ -94,8 +94,7 @@ func localCommonHealthcheck(ctx context.Context, hh *healthcheck.Helper, cli *cl
 					},
 				},
 				Sysctls: map[string]string{
-					"net.core.somaxconn":             "150000",
-					"net.netfilter.nf_conntrack_max": "120000",
+					"net.core.somaxconn": "150000",
 				},
 				RestartPolicy: container.RestartPolicy{
 					Name: "unless-stopped",


### PR DESCRIPTION
In commit ba09c0ecbe8d0ebcee64d1f44784e74f5f104909 `nf_conntrack_max` was deleted in the setting of container `testground-redis`. However, for container `testground-sync-service`, there is still a remain `nf_conntrack_max` so I can not run my test.

log:
```
ERROR   starting container failed       {"container_name": "testground-sync-service", "container_name": "testground-sync-service", "error": "Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: write sysctl key net.netfilter.nf_conntrack_max: open /proc/sys/net/netfilter/nf_conntrack_max: permission denied: unknown"}
```