### PR TITLE
fix: handle http error on client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -537,5 +537,14 @@ func (c *Client) request(ctx context.Context, method string, path string, body i
 	if err != nil {
 		return nil, err
 	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("unexpected status code received: %s", resp.Status)
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		return nil, fmt.Errorf("unexpected content-type received: %s", ct)
+	}
+
 	return resp.Body, nil
 }


### PR DESCRIPTION
This adds some logic to the client to handle HTTP errors. We return an error in case the status code is >= 400 or if the content type is not JSON.

This fixes #1198 as the problem is not Testground by itself, but the lack of presenting the actual error.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>