### PR TITLE
chore: update to xcode 13.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
 
   build-macos:
     macos:
-      xcode: 11.3.0
+      xcode: 13
     steps:
       - setup-macos
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
 
   build-macos:
     macos:
-      xcode: 13
+      xcode: 13.2.0
     steps:
       - setup-macos
       - run:


### PR DESCRIPTION
Updating xcode as the current version is being deprecated on Circle CI: https://github.com/circleci/circleci-docs/pull/6054