### PR TITLE
Allow connecting to additional containers on the control network

### DIFF
--- a/pkg/sidecar/docker_reactor.go
+++ b/pkg/sidecar/docker_reactor.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package sidecar
 
@@ -77,6 +78,12 @@ func (d *DockerReactor) ResolveServices(runid string) {
 		os.Getenv(EnvRedisHost), // NOTE: kept for backwards compatibility with older SDKs.
 		os.Getenv(EnvSyncServiceHost),
 		os.Getenv(EnvInfluxdbHost),
+	}
+
+	additionalHosts := strings.Split(os.Getenv(EnvAdditionalHosts), ",")
+	logging.S().Infow("additional hosts", "hosts", os.Getenv(EnvAdditionalHosts))
+	if len(additionalHosts) != 1 || additionalHosts[0] != "" {
+		wantedRoutes = append(wantedRoutes, additionalHosts...)
 	}
 
 	var resolvedRoutes []net.IP

--- a/pkg/sidecar/sidecar_linux.go
+++ b/pkg/sidecar/sidecar_linux.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package sidecar
 
@@ -13,6 +14,7 @@ const (
 	EnvRedisHost       = "REDIS_HOST" // NOTE: kept for backwards compatibility with older SDKs.
 	EnvSyncServiceHost = "SYNC_SERVICE_HOST"
 	EnvInfluxdbHost    = "INFLUXDB_HOST"
+	EnvAdditionalHosts = "ADDITIONAL_HOSTS"
 )
 
 var runners = map[string]func() (Reactor, error){


### PR DESCRIPTION
# Goals

Allow uses to connect to their own containers that they've spun up on the control network when using local docker.

I wanted to be able to ship spans to a jaeger instance I started on the testground-control network. Originally I thought I'd just use the fact that it was portmapped to host to accomplish this, but that didn't work. Instead, I spun it up on the control network manually then added this code and an entry in my env.toml to allow connecting to it.

I'm not sure if this is the best way to do this -- it'd be great if you could simply specify additional containers to start with the daemon as part of the healthcheck. Note that I want to go looks at spans after the test run is complete, so it can't simply start with the test run.