### PR TITLE
make ping-pong example work on arm machines

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -19,7 +19,7 @@ COPY . /
 # Testground version
 ARG TG_VERSION
 
-RUN cd / && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/testground/testground/pkg/version.GitCommit=${TG_VERSION}" -o testground
+RUN cd / && CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/testground/testground/pkg/version.GitCommit=${TG_VERSION}" -o testground
 
 #:::
 #::: RUNTIME CONTAINER

--- a/Dockerfile.testground
+++ b/Dockerfile.testground
@@ -19,7 +19,7 @@ COPY . /
 # Testground version
 ARG TG_VERSION
 
-RUN cd / && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/testground/testground/pkg/version.GitCommit=${TG_VERSION}" -o testground
+RUN cd / && CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/testground/testground/pkg/version.GitCommit=${TG_VERSION}" -o testground
 
 #:::
 #::: RUNTIME CONTAINER

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -571,7 +571,7 @@ ARG GO_PROXY=direct
 # BUILD_TAGS is either nothing, or when expanded, it expands to "-tags <comma-separated build tags>"
 ARG BUILD_TAGS
 
-# TESTPLAN_EXEC_PKG is the executable package within this test plan we want to build. 
+# TESTPLAN_EXEC_PKG is the executable package within this test plan we want to build.
 ENV TESTPLAN_EXEC_PKG ${TESTPLAN_EXEC_PKG}
 
 # We explicitly set GOCACHE under the /go directory for more tidiness.
@@ -606,7 +606,7 @@ COPY . /
 
 RUN cd ${PLAN_DIR} \
     && go env -w GOPROXY="${GO_PROXY}" \
-    && CGO_ENABLED=${CgoEnabled} GOOS=linux GOARCH=amd64 go build -o ${PLAN_DIR}/testplan.bin ${BUILD_TAGS} ${TESTPLAN_EXEC_PKG}
+    && CGO_ENABLED=${CgoEnabled} GOOS=linux go build -o ${PLAN_DIR}/testplan.bin ${BUILD_TAGS} ${TESTPLAN_EXEC_PKG}
 
 {{.DockerfileExtensions.PostBuild}}
 
@@ -635,7 +635,7 @@ COPY --from=builder ${PLAN_DIR}/testplan.bin /testplan
 
 {{ else }}
 
-## The 'AS runtime' token is used to parse Docker stdout to extract the build image ID to cache. 
+## The 'AS runtime' token is used to parse Docker stdout to extract the build image ID to cache.
 FROM builder AS runtime
 
 # PLAN_DIR is the location containing the plan source inside the build container.


### PR DESCRIPTION
This resolves https://github.com/testground/testground/issues/1263 but I don't know enough about `testground` yet to estimate the blast radius of this change/propose a better solution.

I identified https://github.com/testground/testground/blob/master/pkg/sidecar/docker_reactor.go#L274 to be the call that fails on M1s.

Here's a tiny test that reproduces the issue:
```
package main

import (
  "log"
  "golang.org/x/sys/unix"
)


/*
  To run this test, save this file as `test.go` and execute this command on arm64 machine:
    ✅ docker run --rm -v $(pwd):/home -w /home -e GOARCH=arm64 golang:1.16-buster go run test.go
    ❌ docker run --rm -v $(pwd):/home -w /home -e GOARCH=amd64 golang:1.16-buster go run test.go
*/
func main() {
  /*
    Checking protocols from: https://github.com/vishvananda/netlink/blob/main/nl/nl_linux.go#L35
    ✅ unix.NETLINK_ROUTE
    ❌ unix.NETLINK_XFRM
    ❌ unix.NETLINK_NETFILTER
  */
  protocol := unix.NETLINK_NETFILTER
  fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW|unix.SOCK_CLOEXEC, protocol)
  if err != nil {
    log.Fatal(err)
  }
  log.Println(fd)
}
```

In the original stacktrace, the call that I used in my test is made here: https://github.com/vishvananda/netlink/blob/main/nl/nl_linux.go#L614

I also checked if we can check the handle creation call to `netlink.NewHandleAt(nshandle, unix.NETLINK_ROUTE)` but then the sidecar just fails further down the line with:
```
failed to initialize link default (eth1): failed to set root qdisc: operation not supported
```