### PR TITLE
plans/example-js: fix test using new default client

### DIFF
--- a/plans/example-js/failure.js
+++ b/plans/example-js/failure.js
@@ -1,4 +1,4 @@
-module.exports = async (runenv) => {
+module.exports = async (runenv, client) => {
   runenv.recordMessage('This is what happens when there is a failure')
   throw new Error('intentional oops')
 }

--- a/plans/example-js/output.js
+++ b/plans/example-js/output.js
@@ -1,6 +1,6 @@
 // Demonstrate test output functions
 // This method emits two Messages and one Metric (TODO)
-module.exports = async (runenv) => {
+module.exports = async (runenv, client) => {
   runenv.recordMessage('Hello, World.')
   runenv.recordMessage(`Additional arguments: ${JSON.stringify(runenv.testInstanceParams)}`)
   // runenv.R().RecordPoint("donkeypower", 3.0)

--- a/plans/example-js/package-lock.json
+++ b/plans/example-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@testground/sdk": "^0.1.0"
+        "@testground/sdk": "^0.1.2"
       },
       "devDependencies": {
         "standard": "^14.3.4"
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@testground/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@testground/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-t1xQxilpWsD8JeTDcHsCtiexl+S4G420tgbV/aeJqRxee1kF07lXl/qblIufPn7a6t2m0Izi0/5loD4i76TAXg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@testground/sdk/-/sdk-0.1.2.tgz",
+      "integrity": "sha512-QDUcJbeHR1w/JpSSCid2DxDD00w6yT4p3WQfFspz2ryxR0zvR0ZlJZ0GxmElwAB57Re9rVsNywhaL0oG8Tuavw==",
       "dependencies": {
         "emittery": "^0.10.0",
         "ipaddr.js": "^2.0.1",
@@ -2758,9 +2758,9 @@
       }
     },
     "@testground/sdk": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@testground/sdk/-/sdk-0.1.0.tgz",
-      "integrity": "sha512-t1xQxilpWsD8JeTDcHsCtiexl+S4G420tgbV/aeJqRxee1kF07lXl/qblIufPn7a6t2m0Izi0/5loD4i76TAXg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@testground/sdk/-/sdk-0.1.2.tgz",
+      "integrity": "sha512-QDUcJbeHR1w/JpSSCid2DxDD00w6yT4p3WQfFspz2ryxR0zvR0ZlJZ0GxmElwAB57Re9rVsNywhaL0oG8Tuavw==",
       "requires": {
         "emittery": "^0.10.0",
         "ipaddr.js": "^2.0.1",

--- a/plans/example-js/package.json
+++ b/plans/example-js/package.json
@@ -13,6 +13,6 @@
     "standard": "^14.3.4"
   },
   "dependencies": {
-    "@testground/sdk": "^0.1.0"
+    "@testground/sdk": "^0.1.2"
   }
 }

--- a/plans/example-js/pingpong.js
+++ b/plans/example-js/pingpong.js
@@ -4,14 +4,14 @@ const ipaddr = require('ipaddr.js')
 const { performance } = require('perf_hooks')
 const { sync, network } = require('@testground/sdk')
 
-async function pingpong (runenv) {
+
+async function pingpong (runenv, client) {
   runenv.recordMessage('before sync.newBoundClient')
 
   if (!runenv.testSidecar) {
-    return
+    throw new Error('this test requires a sidecar.')
   }
 
-  const client = await sync.newBoundClient(runenv)
   let server, socket
 
   try {
@@ -150,7 +150,6 @@ async function pingpong (runenv) {
     runenv.recordMessage('ping pong')
     await pingPong('10', 20, 35)
   } finally {
-    client.close()
     if (server) server.close()
     if (socket) socket.destroy()
   }

--- a/plans/example-js/sync.js
+++ b/plans/example-js/sync.js
@@ -17,65 +17,58 @@ function getRandom (min, max) {
 //
 // The leader waits until all the followers have reached the state "ready"
 // then, the followers wait for a signal from the leader to be released.
-module.exports = async (runenv) => {
+module.exports = async (runenv, client) => {
   const enrolledState = 'enrolled'
   const readyState = 'ready'
   const releasedState = 'released'
 
-  // instantiate a sync service client, binding it to the runenv.
-  const client = await sync.newBoundClient(runenv)
+  // instantiate a network client; see 'Traffic shaping' in the docs.
+  const netclient = network.newClient(client, runenv)
+  runenv.recordMessage('waiting for network initialization')
 
-  try {
-    // instantiate a network client; see 'Traffic shaping' in the docs.
-    const netclient = network.newClient(client, runenv)
-    runenv.recordMessage('waiting for network initialization')
+  // wait for the network to initialize; this should be pretty fast.
+  netclient.waitNetworkInitialized()
+  runenv.recordMessage('network initilization complete')
 
-    // wait for the network to initialize; this should be pretty fast.
-    netclient.waitNetworkInitialized()
-    runenv.recordMessage('network initilization complete')
+  // signal entry in the 'enrolled' state, and obtain a sequence number.
+  const seq = await client.signalEntry(enrolledState)
+  runenv.recordMessage(`my sequence ID: ${seq}`)
 
-    // signal entry in the 'enrolled' state, and obtain a sequence number.
-    const seq = await client.signalEntry(enrolledState)
-    runenv.recordMessage(`my sequence ID: ${seq}`)
+  // if we're the first instance to signal, we'll become the LEADER.
+  if (seq === 1) {
+    runenv.recordMessage('i am the leader.')
+    const numFollowers = runenv.testInstanceCount - 1
 
-    // if we're the first instance to signal, we'll become the LEADER.
-    if (seq === 1) {
-      runenv.recordMessage('i am the leader.')
-      const numFollowers = runenv.testInstanceCount - 1
-
-      // let's wait for the followers to signal.
-      runenv.recordMessage(`waiting for ${numFollowers} instances to become ready`)
-      const b = await client.barrier(readyState, numFollowers)
-      await b.wait
-
-      runenv.recordMessage('the followers are all ready')
-      runenv.recordMessage('ready...')
-      await sleep(1000) // 1s
-      runenv.recordMessage('set...')
-      await sleep(5000) // 5s
-      runenv.recordMessage('go, release followers!')
-
-      // signal on the 'released' state.
-      await client.signalEntry(releasedState)
-      return
-    }
-
-    const ms = getRandom(1, 5) * 1000
-    runenv.recordMessage(`i am a follower; signalling ready after ${ms} milliseconds`)
-
-    await sleep(ms)
-
-    runenv.recordMessage('follower signalling now')
-
-    // signal entry in the 'ready' state.
-    await client.signalEntry(readyState)
-
-    // wait until the leader releases us.
-    const b = await client.barrier(releasedState, 1)
+    // let's wait for the followers to signal.
+    runenv.recordMessage(`waiting for ${numFollowers} instances to become ready`)
+    const b = await client.barrier(readyState, numFollowers)
     await b.wait
 
-    runenv.recordMessage('i have been released')
-  } finally {
-    client.close()
+    runenv.recordMessage('the followers are all ready')
+    runenv.recordMessage('ready...')
+    await sleep(1000) // 1s
+    runenv.recordMessage('set...')
+    await sleep(5000) // 5s
+    runenv.recordMessage('go, release followers!')
+
+    // signal on the 'released' state.
+    await client.signalEntry(releasedState)
+    return
   }
+
+  const ms = getRandom(1, 5) * 1000
+  runenv.recordMessage(`i am a follower; signalling ready after ${ms} milliseconds`)
+
+  await sleep(ms)
+
+  runenv.recordMessage('follower signalling now')
+
+  // signal entry in the 'ready' state.
+  await client.signalEntry(readyState)
+
+  // wait until the leader releases us.
+  const b = await client.barrier(releasedState, 1)
+  await b.wait
+
+  runenv.recordMessage('i have been released')
 }


### PR DESCRIPTION
Fixes #1303 

The javascript examples always end in "failure" because we never emit the success signal to the sync service.
This PR adds a `client` parameter inside javascript tests, which triggers the initialization of the sync client.

It's similar to the `InitializedTestCaseFn` used in go examples,
See https://github.com/testground/sdk-js/pull/22