### PR TITLE
fix: update test & ci to use the sync service

### DIFF
--- a/.circleci/sync-service.yaml
+++ b/.circleci/sync-service.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: testground-sync-service
 spec:
+  replicas: 1
   selector:
     matchLabels:
       name: testground-sync-service

--- a/Makefile
+++ b/Makefile
@@ -80,5 +80,8 @@ kind-cluster:
 	kubectl label nodes kind-control-plane testground.node.role.infra=true
 	kind load docker-image iptestground/sidecar:edge
 	kubectl apply -f .circleci/sidecar.yaml
+
 	kind load docker-image iptestground/sync-service:latest
 	kubectl apply -f .circleci/sync-service.yaml
+	kubectl expose deployment/testground-sync-service
+	kubectl port-forward deployment/testground-sync-service 5050:5050 &

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -317,7 +317,7 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 
 		env := conv.ToEnvVar(runenv.ToEnvVars())
 		env = append(env, v1.EnvVar{Name: "REDIS_HOST", Value: "testground-infra-redis-headless"})
-		env = append(env, v1.EnvVar{Name: "SYNC_SERVICE_HOST", Value: "testground-sync-service-headless"})
+		env = append(env, v1.EnvVar{Name: "SYNC_SERVICE_HOST", Value: "testground-sync-service"})
 		env = append(env, v1.EnvVar{Name: "INFLUXDB_URL", Value: "http://influxdb:8086"})
 
 		// Set the log level if provided in cfg.

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -733,9 +733,9 @@ func (c *ClusterK8sRunner) watchRunPods(ctx context.Context, ow *rpc.OutputWrite
 
 	go func() {
 		for ge := range eventsChan {
-			e := ge.Object.(*v1.Event)
+			e, ok := ge.Object.(*v1.Event)
 
-			if strings.Contains(e.InvolvedObject.Name, input.RunID) {
+			if ok && strings.Contains(e.InvolvedObject.Name, input.RunID) {
 				id := e.ObjectMeta.Name
 
 				event := fmt.Sprintf("obj<%s> type<%s> reason<%s> message<%s> type<%s> count<%d> lastTimestamp<%s>", e.InvolvedObject.Name, ge.Type, e.Reason, e.Message, e.Type, e.Count, e.LastTimestamp)

--- a/plans/placebo/main.go
+++ b/plans/placebo/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"time"
 
 	"github.com/testground/sdk-go/run"
 	"github.com/testground/sdk-go/runtime"
+	"github.com/testground/sdk-go/sync"
 )
 
 func main() {
@@ -13,21 +15,39 @@ func main() {
 }
 
 var testcases = map[string]interface{}{
-	"ok":    run.InitializedTestCaseFn(ok),
-	"panic": run.InitializedTestCaseFn(panickingTest),
-	"stall": run.InitializedTestCaseFn(stall),
+	"ok":    ok,
+	"panic": panickingTest,
+	"stall": stall,
 }
 
-func ok(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
+func ok(runenv *runtime.RunEnv) error {
+	minimalInit(runenv)
+
 	return nil
 }
 
-func panickingTest(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
+func panickingTest(runenv *runtime.RunEnv) error {
+	minimalInit(runenv)
+
 	panic(errors.New("this is an intentional panic"))
 }
 
-func stall(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
+func stall(runenv *runtime.RunEnv) error {
+	minimalInit(runenv)
+
 	runenv.RecordMessage("Now stalling for 24 hours")
 	time.Sleep(24 * time.Hour)
 	return nil
+}
+
+// Initialize the sync client and attach it,
+// This replaces the `run.InitializedTestCaseFn` wrapper for
+// tests that are used in integration, where the `MustWaitNetworkInitialized` call hangs.
+//
+// Do not close the client because the SDK uses this at the end of the test to send the success event
+// to the sync service.
+func minimalInit(runenv *runtime.RunEnv) {
+	ctx := context.Background()
+	client := sync.MustBoundClient(ctx, runenv)
+	runenv.AttachSyncClient(client)
 }

--- a/plans/placebo/main.go
+++ b/plans/placebo/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/testground/sdk-go/run"
@@ -10,21 +9,25 @@ import (
 )
 
 func main() {
-	run.Invoke(runf)
+	run.InvokeMap(testcases)
 }
 
-func runf(runenv *runtime.RunEnv) error {
-	switch c := runenv.TestCase; c {
-	case "ok":
-		return nil
-	case "panic":
-		// panic
-		panic(errors.New("this is an intentional panic"))
-	case "stall":
-		// stall
-		time.Sleep(24 * time.Hour)
-		return nil
-	default:
-		return fmt.Errorf("aborting")
-	}
+var testcases = map[string]interface{}{
+	"ok":    run.InitializedTestCaseFn(ok),
+	"panic": run.InitializedTestCaseFn(panickingTest),
+	"stall": run.InitializedTestCaseFn(stall),
+}
+
+func ok(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
+	return nil
+}
+
+func panickingTest(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
+	panic(errors.New("this is an intentional panic"))
+}
+
+func stall(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
+	runenv.RecordMessage("Now stalling for 24 hours")
+	time.Sleep(24 * time.Hour)
+	return nil
 }


### PR DESCRIPTION
We're patching `testground run --wait` to make the CLI exit code consistent with the testground outcome in https://github.com/testground/testground/pull/1347. We want to make sure that if the test outcome is a failure, the command fails.

But now, integrations tests in #1347 fail because the `placebo` test outcome is `failure` (see comments in #1304 for more details) and the CLI catches this outcome (which is the new, expected, behavior).

## Todo

- [x] Update the tests to signal success to the sync service
- [x] Tweak the CI setup (kind) to get minimal testground support
- [x] Fix the status conversion error in k8s
