### PR TITLE
Upgrade to go 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 parameters:
   go-version:
     type: string
-    default: "1.16"
+    default: "1.18"
   workspace-dir:
     type: string
     default: "/home/circleci"
@@ -31,9 +31,9 @@ commands:
           name: "install go on macOS"
           command: |
             brew --version
-            [ ! -d /usr/local/opt/go@1.16 ] && brew install go@1.16 && echo "done installing go"
+            [ ! -d /usr/local/opt/go@1.18 ] && brew install go@1.18 && echo "done installing go"
             echo 'export GOPATH="$HOME/go"' >> $BASH_ENV
-            echo 'export PATH="/usr/local/opt/go@1.16/bin:$GOPATH/bin:$PATH"' >> $BASH_ENV
+            echo 'export PATH="/usr/local/opt/go@1.18/bin:$GOPATH/bin:$PATH"' >> $BASH_ENV
             source $BASH_ENV
             go version
       - checkout

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -3,7 +3,7 @@
 #:::
 
 # GO_VERSION is the golang version this image will be built against.
-ARG GO_VERSION=1.16
+ARG GO_VERSION=1.18
 
 # Dynamically select the golang version.
 FROM golang:${GO_VERSION}-buster

--- a/Dockerfile.testground
+++ b/Dockerfile.testground
@@ -3,7 +3,7 @@
 #:::
 
 # GO_VERSION is the golang version this image will be built against.
-ARG GO_VERSION=1.16
+ARG GO_VERSION=1.18
 
 # Dynamically select the golang version.
 FROM golang:${GO_VERSION}-buster

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ from 2 to 10k instances, only when needed.
 
 _NOTE: currently, we don't distribute binaries, so you will have to build from source._
 
-***Prerequisites: Go 1.16+, Docker daemon running.***
+***Prerequisites: Go 1.18+, Docker daemon running.***
 
 ```shell script
 $ git clone https://github.com/testground/testground.git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/testground/testground
 
-go 1.16
+go 1.18
 
 require (
 	github.com/BurntSushi/toml v0.4.1
@@ -41,4 +41,85 @@ require (
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
+)
+
+require (
+	cloud.google.com/go v0.54.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/Microsoft/go-winio v0.4.16 // indirect
+	github.com/Microsoft/hcsshim v0.8.7 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/avast/retry-go v2.6.0+incompatible // indirect
+	github.com/containerd/containerd v1.3.4 // indirect
+	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/dsnet/compress v0.0.1 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.3.1 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-playground/locales v0.14.0 // indirect
+	github.com/go-playground/universal-translator v0.18.0 // indirect
+	github.com/gobuffalo/here v0.6.2 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
+	github.com/klauspost/compress v1.10.3 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/markbates/pkger v0.15.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/nwaples/rardecode v1.1.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/opencontainers/runc v0.1.1 // indirect
+	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.4.2 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/testground/sync-service v0.1.0 // indirect
+	github.com/ulikunitz/xz v0.5.7 // indirect
+	github.com/xanzy/ssh-agent v0.3.0 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	google.golang.org/appengine v1.6.5 // indirect
+	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
+	google.golang.org/grpc v1.29.1 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/klog/v2 v2.9.0 // indirect
+	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect
+	nhooyr.io/websocket v1.8.6 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -512,7 +512,6 @@ github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLY
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5 h1:MCfT24H3f//U5+UCrZp1/riVO3B50BovxtDiNn0XKkk=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
@@ -882,7 +881,6 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=
@@ -899,7 +897,6 @@ nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	DefaultGoBuildBaseImage = "golang:1.16-buster"
+	DefaultGoBuildBaseImage = "golang:1.18-buster"
 
 	buildNetworkName = "testground-build"
 )
@@ -81,7 +81,7 @@ type DockerGoBuilderConfig struct {
 	RuntimeImage string `toml:"runtime_image"`
 
 	// BuildBaseImage is the base build image that the test plan binary will be
-	// built from. Defaults to golang:1.16-buster
+	// built from. Defaults to golang:1.18-buster
 	BuildBaseImage string `toml:"build_base_image"`
 
 	// SkipRuntimeImage allows you to skip putting the build output in a

--- a/plans/benchmarks/go.mod
+++ b/plans/benchmarks/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/testround/plans/benchmarks
 
-go 1.16
+go 1.18
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/plans/dockercustomize/go.mod
+++ b/plans/dockercustomize/go.mod
@@ -1,6 +1,6 @@
 module github.com/testground/testground/plans/dockercustomize
 
-go 1.16
+go 1.18
 
 require (
 	github.com/pkg/errors v0.9.1 // indirect

--- a/plans/dockercustomize/manifest.toml
+++ b/plans/dockercustomize/manifest.toml
@@ -7,7 +7,7 @@ runner = "local:docker"
 [builders."docker:go"]
 enabled = true
 runtime_image = "debian"
-build_base_image = "golang:1.16-buster"
+build_base_image = "golang:1.18-buster"
 enable_go_build_cache = true
 # skip_runtime_image = true
 

--- a/plans/example/go.mod
+++ b/plans/example/go.mod
@@ -1,5 +1,5 @@
 module github.com/ipfs/testround/plans/example
 
-go 1.16
+go 8
 
 require github.com/testground/sdk-go v0.3.1-0.20211012114808-49c90fa75405

--- a/plans/network/go.mod
+++ b/plans/network/go.mod
@@ -1,5 +1,5 @@
 module github.com/testground/testground/plans/network
 
-go 1.16
+go 1.18
 
 require github.com/testground/sdk-go v0.3.1-0.20211012114808-49c90fa75405

--- a/plans/placebo/go.mod
+++ b/plans/placebo/go.mod
@@ -1,5 +1,5 @@
 module github.com/testground/testground/plans/placebo
 
-go 1.16
+go 1.18
 
 require github.com/testground/sdk-go v0.3.1-0.20211012114808-49c90fa75405

--- a/plans/splitbrain/go.mod
+++ b/plans/splitbrain/go.mod
@@ -1,5 +1,5 @@
 module github.com/testground/testground/plans/splitbrain
 
-go 1.16
+go 1.18
 
 require github.com/testground/sdk-go v0.3.1-0.20211012114808-49c90fa75405

--- a/plans/verify/go.mod
+++ b/plans/verify/go.mod
@@ -1,6 +1,6 @@
 module github.com/testground/testround/plans/verify
 
-go 1.16
+go 1.18
 
 require (
 	github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c


### PR DESCRIPTION
I'm attempting to stress test our [client](https://github.com/statechannels/go-nitro) which was written with go 1.18. Since the docker containers only use go 1.16 building the test via docker would fail. 

To fix this I've upgraded our fork of testground to go 1.18 (mostly done by finding and replacing). I figured I'd raise a PR in case it's helpful in any way.