### PR TITLE
Do not specify GOARCH when building to support arm64

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -19,7 +19,7 @@ COPY . /
 # Testground version
 ARG TG_VERSION
 
-RUN cd / && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/testground/testground/pkg/version.GitCommit=${TG_VERSION}" -o testground
+RUN cd / && CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/testground/testground/pkg/version.GitCommit=${TG_VERSION}" -o testground
 
 #:::
 #::: RUNTIME CONTAINER

--- a/Dockerfile.testground
+++ b/Dockerfile.testground
@@ -19,7 +19,7 @@ COPY . /
 # Testground version
 ARG TG_VERSION
 
-RUN cd / && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/testground/testground/pkg/version.GitCommit=${TG_VERSION}" -o testground
+RUN cd / && CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/testground/testground/pkg/version.GitCommit=${TG_VERSION}" -o testground
 
 #:::
 #::: RUNTIME CONTAINER

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -640,7 +640,7 @@ RUN cp /tmp/go.mod /tmp/go.sum ${PLAN_DIR}/
 
 RUN cd ${PLAN_DIR} \
     && go env -w GOPROXY="${GO_PROXY}" \
-    && CGO_ENABLED=${CgoEnabled} GOOS=linux GOARCH=amd64 go build -o ${PLAN_DIR}/testplan.bin ${BUILD_TAGS} ${TESTPLAN_EXEC_PKG}
+    && CGO_ENABLED=${CgoEnabled} GOOS=linux go build -o ${PLAN_DIR}/testplan.bin ${BUILD_TAGS} ${TESTPLAN_EXEC_PKG}
 
 {{.DockerfileExtensions.PostBuild}}
 


### PR DESCRIPTION
Fixes #1298 

This is the same change as https://github.com/testground/testground/pull/1296 but has been rebased on the latest `master`.

It removes `GOARCH=amd64` when calling go build which would fail on `arm64` machines (like M1 macs). We've been used this in our fork to use testground on m1 macs.

