### PR TITLE
Fix HTTP static file serving

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -77,8 +77,8 @@ func New(cfg *config.EnvConfig) (srv *Daemon, err error) {
 		})
 	})
 
-	staticDir := "/static/"
-	r.PathPrefix(staticDir).Handler(http.StripPrefix(staticDir, http.FileServer(http.Dir("."+staticDir))))
+	staticPrefix := "/static/"
+	r.PathPrefix(staticPrefix).Handler(http.StripPrefix(staticPrefix, http.FileServer(http.Dir("./static"))))
 
 	r.HandleFunc("/data", srv.dataHandler(engine)).Methods("GET")
 	r.HandleFunc("/dashboard", srv.dashboardHandler(engine)).Methods("GET")


### PR DESCRIPTION
When trying to access the http server for the daemon I noticed that the static css/js files didn't seem to load:

![image](https://user-images.githubusercontent.com/1620336/178067038-ee093c73-7777-496c-953e-1ccfae241563.png)

Removing the trailing slash in the path passed into `http.Dir` seemed to resolve this and allow the HTTP server to properly serve up the static files.