### PR TITLE
Fix storm test

### DIFF
--- a/plans/benchmarks/manifest.toml
+++ b/plans/benchmarks/manifest.toml
@@ -57,6 +57,6 @@ instances = { min = 1, max = 100000, default = 5 }
   [testcases.params]
   conn_count       = { type = "int", desc = "number of TCP sockets to open", default = 5 }
   conn_outgoing    = { type = "int", desc = "number of outgoing TCP dials", default = 5 }
-  conn_delay       = { type = "int", desc = "random milliseconds jitter before TCP dial", default = 30000 }
+  conn_delay_ms       = { type = "int", desc = "random milliseconds jitter before TCP dial", default = 30000 }
   concurrent_dials = { type = "int", desc = "max number of concurrent net.Dial calls", default = 10 }
   data_size_kb     = { type = "int", desc = "size of data to write to each TCP connection", default = 128 }


### PR DESCRIPTION
The benchmarks/storm test does not work unless this parameter is renamed properly.