### PR TITLE
Fix: testground instability due to race condition on outcomes

### DIFF
--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -184,7 +184,7 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 		return nil, fmt.Errorf("could not init pool: %w", err)
 	}
 
-	result := newResult()
+	result := newResult(input)
 	runoutput = &api.RunOutput{
 		RunID:  input.RunID,
 		Result: result,

--- a/pkg/runner/common.go
+++ b/pkg/runner/common.go
@@ -116,6 +116,6 @@ func gzipRunOutputs(ctx context.Context, basedir string, input *api.CollectionIn
 func reviewResources(group *api.RunGroup, ow *rpc.OutputWriter) {
 	log := ow.With("group_id", group.ID)
 	if group.Resources.CPU != "" || group.Resources.Memory != "" {
-		log.Warnw("group has resources set. note that resources requirement and limits are ignored on the this runner.")
+		log.Warnw("group has resources set. Note that resources requirement and limits are ignored by this runner.")
 	}
 }

--- a/pkg/runner/common_result.go
+++ b/pkg/runner/common_result.go
@@ -30,3 +30,30 @@ func newResult(input *api.RunInput) *Result {
 
 	return result
 }
+
+func (r *Result) addOutcome(groupID string, outcome task.Outcome) {
+	switch outcome {
+	case task.OutcomeSuccess:
+		r.Outcomes[groupID].Ok++
+	default:
+		// skip
+	}
+}
+func (r *Result) countTotalInstances() int {
+	count := 0
+	for _, g := range r.Outcomes {
+		count += g.Total
+	}
+	return count
+}
+
+// TODO: this should be a getter instead of a mutation
+func (r *Result) updateOutcome() {
+	for _, g := range r.Outcomes {
+		if g.Total != g.Ok {
+			r.Outcome = task.OutcomeFailure
+			return
+		}
+	}
+	r.Outcome = task.OutcomeSuccess
+}

--- a/pkg/runner/common_result.go
+++ b/pkg/runner/common_result.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"github.com/testground/testground/pkg/api"
 	"github.com/testground/testground/pkg/task"
 )
 
@@ -10,8 +11,8 @@ type Result struct {
 	Journal  *Journal                 `json:"journal"`
 }
 
-func newResult() *Result {
-	return &Result{
+func newResult(input *api.RunInput) *Result {
+	result := &Result{
 		Outcome:  task.OutcomeUnknown,
 		Outcomes: make(map[string]*GroupOutcome),
 		Journal: &Journal{
@@ -19,4 +20,13 @@ func newResult() *Result {
 			PodsStatuses: make(map[string]struct{}),
 		},
 	}
+
+	for _, g := range input.Groups {
+		result.Outcomes[g.ID] = &GroupOutcome{
+			Total: g.Instances,
+			Ok:    0,
+		}
+	}
+
+	return result
 }

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -201,42 +201,44 @@ func (r *LocalDockerRunner) setupSyncClient() error {
 	return nil
 }
 
-func (r *LocalDockerRunner) collectOutcomes(ctx context.Context, result *Result, tpl *runtime.RunParams) (chan bool, error) {
+// collectContainersOutcomes listens to the sync service and collects the outcome for every test instance.
+// It stops when all instances have submitted a result or the context was canceled.
+func (r *LocalDockerRunner) collectContainersOutcomes(ctx context.Context, result *Result, tpl *runtime.RunParams) (chan bool, error) {
 	eventsCh, err := r.syncClient.SubscribeEvents(ctx, tpl)
 	if err != nil {
 		return nil, err
 	}
 
+	// TODO: eventually we'll keep a trace of each test instance status.
+	// Right now, if a container sends multiple events, it will mess up the outcomes.
+	// We have to pass its group id to the container, so that it can send us back messages
+	// with its own id.
+	expectingOutcomes := result.countTotalInstances()
 	done := make(chan bool)
 
 	go func() {
 		running := true
-		for running {
+		for running && expectingOutcomes > 0 {
 			select {
 			case <-ctx.Done():
 				running = false
 			case e := <-eventsCh:
-				// for now we emit only outcome OK events, so no need for more checks
 				if e.SuccessEvent != nil {
-					se := e.SuccessEvent
-					o := result.Outcomes[se.TestGroupID]
-					o.Ok = o.Ok + 1
+					result.addOutcome(e.SuccessEvent.TestGroupID, task.OutcomeSuccess)
+					expectingOutcomes -= 1
+				} else if e.FailureEvent != nil {
+					result.addOutcome(e.SuccessEvent.TestGroupID, task.OutcomeFailure)
+					expectingOutcomes -= 1
+				} else if e.CrashEvent != nil {
+					result.addOutcome(e.SuccessEvent.TestGroupID, task.OutcomeFailure)
+					expectingOutcomes -= 1
+				} else {
+					// skip
 				}
 			}
 		}
 
-		result.Outcome = task.OutcomeSuccess
-		if len(result.Outcomes) == 0 {
-			result.Outcome = task.OutcomeFailure
-		}
-
-		for g := range result.Outcomes {
-			if result.Outcomes[g].Total != result.Outcomes[g].Ok {
-				result.Outcome = task.OutcomeFailure
-				break
-			}
-		}
-
+		result.updateOutcome()
 		done <- true
 	}()
 
@@ -274,12 +276,6 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		Result: result,
 	}
 
-	// Grab a read lock. This will allow many runs to run simultaneously, but
-	// they will be exclusive of state-altering healthchecks.
-	// TODO: I'm not sure this is true anymore.
-	r.lk.RLock()
-	defer r.lk.RUnlock()
-
 	defer func() {
 		if err != nil {
 			// TODO: maybe replace only if the outcome is a default value.
@@ -295,6 +291,12 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		log.Error(err)
 		return
 	}
+
+	// Grab a read lock. This will allow many runs to run simultaneously, but
+	// they will be exclusive of state-altering healthchecks.
+	// TODO: I'm not sure this is true anymore.
+	r.lk.RLock()
+	defer r.lk.RUnlock()
 
 	// ## Prepare Execution Context
 
@@ -478,25 +480,23 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		return
 	}
 
-	var (
-		doneCh    = make(chan error, 2)
-		started   = make(chan testContainerInstance, len(containers))
-		ratelimit = make(chan struct{}, 16)
-	)
+	// ## Start the containers & log their outputs.
 
-	ctxContainers, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// collect the outcomes in parallel while the process runs.
-	outcomesDoneCh, err := r.collectOutcomes(ctxContainers, result, &template)
+	// First we collect every container outcomes.
+	outcomesCollectIsCompleteCh, err := r.collectContainersOutcomes(ctx, result, &template)
 	if err != nil {
 		log.Error(err)
 		return
 	}
 
+	// Second we start the containers
 	log.Infow("starting containers", "count", len(containers))
+	var (
+		startGroup, startGroupCtx = errgroup.WithContext(ctx)
+		ratelimit                 = make(chan struct{}, 16)
+		started                   = make(chan testContainerInstance, len(containers))
+	)
 
-	g, gctx := errgroup.WithContext(ctxContainers)
 	for _, c := range containers {
 		c := c
 		f := func() error {
@@ -505,37 +505,27 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 
 			log.Infow("starting container", "id", c.containerID, "group", c.groupID, "group_index", c.groupIdx)
 
-			err := cli.ContainerStart(ctx, c.containerID, types.ContainerStartOptions{})
+			err := cli.ContainerStart(startGroupCtx, c.containerID, types.ContainerStartOptions{})
 			if err == nil {
 				log.Debugw("started container", "id", c.containerID, "group", c.groupID, "group_index", c.groupIdx)
 				select {
-				case <-gctx.Done():
+				// TODO: this is a cancel signal. We should race it with the ContainerStart operation.
+				case <-startGroupCtx.Done():
 				default:
 					started <- c
 				}
 			}
+
 			return err
 		}
-		g.Go(f)
+		startGroup.Go(f)
 	}
 
-	// Wait until we're done to close the started channel.
-	go func() {
-		err := g.Wait()
-		close(started)
-
-		if err != nil {
-			log.Error(err)
-			doneCh <- err
-		} else {
-			log.Infow("started containers", "count", len(containers))
-		}
-	}()
-
+	// Third we start the pretty printer
 	if !cfg.Background {
 		pretty := NewPrettyPrinter(ow)
 
-		// This goroutine tails the sidecar container logs and appends them to the pretty printer.
+		// Tail the sidecar container logs and appends them to the pretty printer.
 		go func() {
 			t := time.Now().Add(time.Duration(-10) * time.Second) // sidecar is a long running daemon, so we care only about logs around the execution of our test run
 			stream, err := cli.ContainerLogs(ctx, "testground-sidecar", types.ContainerLogsOptions{
@@ -546,8 +536,8 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 			})
 
 			if err != nil {
-				doneCh <- err
-				return
+				// TODO: handle
+				log.Errorw("failed to attach sidecar", "error", err)
 			}
 
 			rstdout, wstdout := io.Pipe()
@@ -561,17 +551,14 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 			pretty.Append("sidecar     ", rstdout, rstderr)
 		}()
 
+		// Tail the other container logs and appends them to the pretty printer.
 		// This goroutine takes started containers and attaches them to the pretty printer.
 		go func() {
-		Outer:
 			for {
 				select {
-				case tc, more := <-started:
-					if !more {
-						break Outer
-					}
-
-					stream, err := cli.ContainerLogs(ctx, tc.containerID, types.ContainerLogsOptions{
+				case c := <-started:
+					log.Infow("attaching container", "id", c.containerID, "group", c.groupID, "group_index", c.groupIdx)
+					stream, err := cli.ContainerLogs(ctx, c.containerID, types.ContainerLogsOptions{
 						ShowStdout: true,
 						ShowStderr: true,
 						Since:      "2019-01-01T00:00:00",
@@ -579,8 +566,9 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 					})
 
 					if err != nil {
-						doneCh <- err
-						return
+						// TODO: handle
+						log.Errorw("failed to attach container", "id", c.containerID, "group", c.groupID, "group_index", c.groupIdx, "error", err)
+						continue
 					}
 
 					rstdout, wstdout := io.Pipe()
@@ -592,37 +580,81 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 					}()
 
 					// instance tag in output: << group[zero_padded_i] >> (container_id[0:6]), e.g. << miner[003] (a1b2c3) >>
-					tag := fmt.Sprintf("%s[%03d] (%s)", tc.groupID, tc.groupIdx, tc.containerID[0:6])
+					tag := fmt.Sprintf("%s[%03d] (%s)", c.groupID, c.groupIdx, c.containerID[0:6])
 					pretty.Manage(tag, rstdout, rstderr)
-
 				case <-ctx.Done():
-					// yield if we've been cancelled.
-					doneCh <- ctx.Err()
+					// Exit
 					return
 				}
-			}
-
-			select {
-			case err := <-pretty.Wait():
-				doneCh <- err
-			case <-ctx.Done():
-				log.Error(ctx) // yield if we're been cancelled.
-				doneCh <- ctx.Err()
 			}
 		}()
 	}
 
-	select {
-	case err = <-doneCh:
-	case <-ctx.Done():
-		err = ctx.Err()
+	// Wait for all container to have started
+	err = startGroup.Wait()
+	if err != nil {
+		log.Error(err)
+		return
 	}
 
-	cancel()
+	// Finally, we're going to follow our containers until they are done
+	runGroup, runGroupCtx := errgroup.WithContext(ctx)
 
-	// NOTE: we wait for the outcome done channel here,
-	// but it doesn't really wait for our containers results.
-	<-outcomesDoneCh
+	for _, c := range containers {
+		c := c
+		f := func() error {
+			log.Infow("waiting for container", "id", c.containerID, "group", c.groupID, "group_index", c.groupIdx)
+
+			// TODO: Make sure we wait on a context that will be canceled if the group is canceled.
+			statusCh, errCh := cli.ContainerWait(ctx, c.containerID, container.WaitConditionNotRunning)
+
+			select {
+			case err := <-errCh:
+				if err != nil {
+					return err
+				}
+				return nil
+				// TODO: This channel output and error field and the container exit status,
+				// make sure we don't miss any error. And use the container's exit status to provide more logging.
+			case <-statusCh:
+				return nil
+			case <-runGroupCtx.Done(): // race with the group
+				return nil
+			}
+		}
+		startGroup.Go(f)
+	}
+
+	// When we're here, our containers are started, the outcomes are being collected.
+	// We waint until either:
+	// - all container are done and the outcomes are done
+	// - we reach a timeout.
+
+	containersAreCompleteCh := make(chan bool)
+
+	go func() {
+		err = runGroup.Wait()
+		containersAreCompleteCh <- true
+	}()
+
+	waitingForContainers := true
+	waitingForOutcomes := true
+
+	log.Info("Containers started, waiting for containers and outcome signals")
+	for waitingForContainers || waitingForOutcomes {
+		select {
+		case <-containersAreCompleteCh:
+			log.Infow("all containers are complete")
+			waitingForContainers = false
+		case <-outcomesCollectIsCompleteCh:
+			log.Infow("all outcomes are complete")
+			waitingForOutcomes = false
+		case <-ctx.Done():
+			log.Infow("test run is canceled")
+			return
+		}
+	}
+
 	return
 }
 

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -420,7 +420,9 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 			for _, c := range containers {
 				ids = append(ids, c.containerID)
 			}
-			_ = docker.DeleteContainers(cli, log, ids)
+			if err := docker.DeleteContainers(cli, log, ids); err != nil {
+				log.Errorw("failed to delete containers", "err", err)
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			if err := cli.NetworkRemove(ctx, dataNetworkID); err != nil {
@@ -557,7 +559,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 					pretty.Manage(tag, rstdout, rstderr)
 
 				case <-ctx.Done():
-					// yield if we're been cancelled.
+					// yield if we've been cancelled.
 					doneCh <- ctx.Err()
 					return
 				}


### PR DESCRIPTION
When the docker runner starts a test run it does a few things:
1. Wait for the instance containers to complete,
2. Setup a "pretty printer" that forwards instance's stdout, BUT ALSO tries to decode events from stdout and update the outcomes, 
3. Listen to the events sent by test instances and update the outcomes on success.

When the containers exits (1) testground stops everything related to collecting the outcomes (3).
This is fine-ish with the go-sdk because it dumps events to stdout as well, so the outcomes will be read thanks to (2).

Logging events on stdout and trying to decode the JSON looked like a legacy hack: this was not implemented in the rust-sdk. See my [notes on the pretty printer](https://github.com/testground/testground/issues/1322#issuecomment-1141209321). The rust-sdk triggers a race condition:

1. test instance sends "success event" to the sync service
2. test instance exits
3. Testgound shuts down the test (and the outcome collection part)
4.  Testground receives the "success event", but does not listen to it anymore.

I believe we've seen this error on go-sdk, less often, see [this comment](https://github.com/testground/testground/issues/1382#issuecomment-1193405557).

This PR rework the local docker runner so that a test is complete if and only if:
- All the instances have exited AND all the outcomes have been received
- OR the test timeout has been reached.

See runs:

- rust-sdk examples with regular testground: https://github.com/laurentsenta/testground-stability/actions/runs/2747857836
- rust-sdk examples with this patch: https://github.com/laurentsenta/testground-stability/actions/runs/2747849325

## Todo

- [x] Spike the patch,
- [ ] Verify that the patch doesn't break other components,
- [ ] Go through all other TODOs (dealing with errors, etc),
- [ ] Double check the outcome outputs and the integration tests results,
- [ ] Look into the testing situation.

