### PR TITLE
fix: testground instability due to race condition on outcomes

### DIFF
--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -184,7 +184,7 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 		return nil, fmt.Errorf("could not init pool: %w", err)
 	}
 
-	result := newResult()
+	result := newResult(input)
 	runoutput = &api.RunOutput{
 		RunID:  input.RunID,
 		Result: result,

--- a/pkg/runner/common.go
+++ b/pkg/runner/common.go
@@ -116,6 +116,6 @@ func gzipRunOutputs(ctx context.Context, basedir string, input *api.CollectionIn
 func reviewResources(group *api.RunGroup, ow *rpc.OutputWriter) {
 	log := ow.With("group_id", group.ID)
 	if group.Resources.CPU != "" || group.Resources.Memory != "" {
-		log.Warnw("group has resources set. note that resources requirement and limits are ignored on the this runner.")
+		log.Warnw("group has resources set. Note that resources requirement and limits are ignored by this runner.")
 	}
 }

--- a/pkg/runner/common_result.go
+++ b/pkg/runner/common_result.go
@@ -30,3 +30,30 @@ func newResult(input *api.RunInput) *Result {
 
 	return result
 }
+
+func (r *Result) addOutcome(groupID string, outcome task.Outcome) {
+	switch outcome {
+	case task.OutcomeSuccess:
+		r.Outcomes[groupID].Ok++
+	default:
+		// skip
+	}
+}
+func (r *Result) countTotalInstances() int {
+	count := 0
+	for _, g := range r.Outcomes {
+		count += g.Total
+	}
+	return count
+}
+
+// TODO: this should be a getter instead of a mutation
+func (r *Result) updateOutcome() {
+	for _, g := range r.Outcomes {
+		if g.Total != g.Ok {
+			r.Outcome = task.OutcomeFailure
+			return
+		}
+	}
+	r.Outcome = task.OutcomeSuccess
+}

--- a/pkg/runner/common_result.go
+++ b/pkg/runner/common_result.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"github.com/testground/testground/pkg/api"
 	"github.com/testground/testground/pkg/task"
 )
 
@@ -10,8 +11,8 @@ type Result struct {
 	Journal  *Journal                 `json:"journal"`
 }
 
-func newResult() *Result {
-	return &Result{
+func newResult(input *api.RunInput) *Result {
+	result := &Result{
 		Outcome:  task.OutcomeUnknown,
 		Outcomes: make(map[string]*GroupOutcome),
 		Journal: &Journal{
@@ -19,4 +20,13 @@ func newResult() *Result {
 			PodsStatuses: make(map[string]struct{}),
 		},
 	}
+
+	for _, g := range input.Groups {
+		result.Outcomes[g.ID] = &GroupOutcome{
+			Total: g.Instances,
+			Ok:    0,
+		}
+	}
+
+	return result
 }

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -280,8 +280,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 	}
 
 	defer func() {
-		if err != nil {
-			// TODO: maybe replace only if the outcome is a default value.
+		if err != nil && result.Outcome == "" {
 			result.Outcome = task.OutcomeFailure
 		}
 		if ctx.Err() == context.Canceled {

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -633,7 +633,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 	}
 
 	// When we're here, our containers are started, the outcomes are being collected.
-	// We waint until either:
+	// We wait until either:
 	// - all container are done and outcome have been received
 	// - we reach a timeout.
 

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -516,7 +516,6 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 			if err == nil {
 				log.Debugw("started container", "id", c.containerID, "group", c.groupID, "group_index", c.groupIdx)
 				select {
-				// TODO: this is a cancel signal. We should race it with the ContainerStart operation.
 				case <-startGroupCtx.Done():
 				default:
 					started <- c

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -420,7 +420,9 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 			for _, c := range containers {
 				ids = append(ids, c.containerID)
 			}
-			_ = docker.DeleteContainers(cli, log, ids)
+			if err := docker.DeleteContainers(cli, log, ids); err != nil {
+				log.Errorw("failed to delete containers", "err", err)
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			if err := cli.NetworkRemove(ctx, dataNetworkID); err != nil {
@@ -557,7 +559,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 					pretty.Manage(tag, rstdout, rstderr)
 
 				case <-ctx.Done():
-					// yield if we're been cancelled.
+					// yield if we've been cancelled.
 					doneCh <- ctx.Err()
 					return
 				}


### PR DESCRIPTION
Fix #1400
Fix #1382

When the docker runner starts a test run it does a few things:
1. Wait for the instance containers to complete,
2. Setup a "pretty printer" that forwards instance's stdout, BUT ALSO tries to decode events from stdout and update the outcomes, 
3. Listen to the events sent by test instances and update the outcomes on success.

When the containers exits (1) testground stops everything related to collecting the outcomes (3).
This is fine-ish with the go-sdk because it dumps events to stdout as well, so the outcomes will be read thanks to (2).

Logging events on stdout and trying to decode the JSON looked like a legacy hack: this was not implemented in the rust-sdk. See my [notes on the pretty printer](https://github.com/testground/testground/issues/1322#issuecomment-1141209321). The rust-sdk triggers a race condition:

1. test instance sends "success event" to the sync service
2. test instance exits
3. Testgound shuts down the test (and the outcome collection part)
4.  Testground receives the "success event", but does not listen to it anymore.

I believe we've seen this error on go-sdk, less often, see [this comment](https://github.com/testground/testground/issues/1382#issuecomment-1193405557).

This PR rework the local docker runner so that a test is complete if and only if:
- All the instances have exited AND all the outcomes have been received
- All the instances have exited AND a timeout of x seconds have been reached (prevents hanging when an instance crashes)
- OR the test timeout has been reached.

See runs:

- rust-sdk examples with regular testground: https://github.com/laurentsenta/testground-stability/actions/runs/2747857836
- rust-sdk examples with this patch: https://github.com/laurentsenta/testground-stability/actions/runs/2747849325

## Todo

- [x] Spike the patch,
- [x] Verify that the patch doesn't break other components,
- [x] Go through all other TODOs (dealing with errors, etc),
- [x] Double check the outcome outputs and the integration tests results,
- [x] Look into the testing situation.
