### PR TITLE
use Grafana docker image from Grafana instead of Bitnami

### DIFF
--- a/pkg/runner/local_common.go
+++ b/pkg/runner/local_common.go
@@ -34,7 +34,7 @@ func localCommonHealthcheck(ctx context.Context, hh *healthcheck.Helper, cli *cl
 		healthcheck.StartContainer(ctx, ow, cli, &docker.EnsureContainerOpts{
 			ContainerName: "testground-grafana",
 			ContainerConfig: &container.Config{
-				Image: "bitnami/grafana",
+				Image: "grafana/grafana",
 			},
 			HostConfig: &container.HostConfig{
 				PortBindings: exposed,


### PR DESCRIPTION
The Grafana provided image has multi-arch support, while the Bitnami version does not.

This is partial solution to #1408.