### PR TITLE
fix: in docker:go builder, path & modfile options can't be mixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ test-integ-local-docker:
 	./integration_tests/13_02_docker_builder_configuration.sh
 	./integration_tests/14_docker_silent_test_failure.sh
 	./integration_tests/15_docker_mixed_builders_configuration.sh
+	./integration_tests/15_02_docker_mixed_builders_and_custom_go_deps.sh
 	./integration_tests/16_show_task_outcome_in_cli.sh
 
 test-integ-examples:

--- a/integration_tests/15_02_docker_mixed_builders_and_custom_go_deps.sh
+++ b/integration_tests/15_02_docker_mixed_builders_and_custom_go_deps.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Test for https://github.com/testground/testground/issues/1357
+my_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$my_dir/header.sh"
+
+testground plan import --from ./plans/_integrations_mixed_builders --name integrations_mixed_builders
+
+pushd $TEMPDIR
+
+testground build composition -f ${my_dir}/../plans/_integrations_mixed_builders/_compositions/issue-1412-path-and-go-dependencies.toml \
+   --wait
+
+popd

--- a/plans/_integrations_mixed_builders/_compositions/issue-1412-path-and-go-dependencies.toml
+++ b/plans/_integrations_mixed_builders/_compositions/issue-1412-path-and-go-dependencies.toml
@@ -1,0 +1,27 @@
+# Test for https://github.com/testground/testground/issues/1357
+# Introduces:
+#  - `builder' option per group
+#  - `path` option for generic and docker builders
+[metadata]
+  name = "issue-1412-path-and-go-dependencies"
+
+[global]
+  plan = "integrations_mixed_builders"
+  case = "issue-1412-path-and-go-dependencies"
+  total_instances = 1
+  runner = "local:docker"
+
+[[groups]]
+  id = "go"
+  instances = { count = 1 }
+  builder = "docker:go"
+
+  [groups.build_config]
+    path = "go/"
+
+  [groups.build_config.dockerfile_extensions]
+    pre_build = "RUN cd ${PLAN_DIR} && go mod download github.com/testground/sdk-go && go mod tidy"
+
+    [[groups.build.dependencies]]
+      module = "github.com/testground/sdk-go"
+      version = "master"

--- a/plans/_integrations_mixed_builders/go/main.go
+++ b/plans/_integrations_mixed_builders/go/main.go
@@ -9,6 +9,7 @@ import (
 
 var testcases = map[string]interface{}{
 	"issue-1357-mix-builder-configuration": run.InitializedTestCaseFn(overrideBuilderConfiguration),
+	"issue-1412-path-and-go-dependencies":  run.InitializedTestCaseFn(noop),
 }
 
 func main() {
@@ -24,5 +25,9 @@ func overrideBuilderConfiguration(runenv *runtime.RunEnv, initCtx *run.InitConte
 		return errors.New("expected version does not match")
 	}
 
+	return nil
+}
+
+func noop(runenv *runtime.RunEnv, initCtx *run.InitContext) error {
 	return nil
 }

--- a/plans/_integrations_mixed_builders/manifest.toml
+++ b/plans/_integrations_mixed_builders/manifest.toml
@@ -19,3 +19,7 @@ instances = { min = 2, max = 2, default = 2 }
 
 [testcases.params]
   expected_implementation = { type = "string", desc = "expected implementation" }
+
+[[testcases]]
+name = "issue-1412-path-and-go-dependencies"
+instances = { min = 1, max = 1, default = 1 }


### PR DESCRIPTION
Fix #1412 