### PR TITLE
feat: various usability & stabiliy improvements for interop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f
 	github.com/whilp/git-urls v1.0.0
 	go.uber.org/zap v1.19.0
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2

--- a/go.sum
+++ b/go.sum
@@ -649,8 +649,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/api/composition.go
+++ b/pkg/api/composition.go
@@ -59,7 +59,7 @@ type Global struct {
 
 	// TotalInstances defines the total number of instances that participate in
 	// this composition; it is the sum of all instances in all groups.
-	TotalInstances uint `toml:"total_instances" json:"total_instances" validate:"required,gte=0"`
+	TotalInstances uint `toml:"total_instances" json:"total_instances" validate:"gte=0"`
 
 	// Builder is the builder we're using.
 	Builder string `toml:"builder" json:"builder"`
@@ -292,18 +292,28 @@ func (c *Composition) ValidateForRun() error {
 
 	// Calculate instances per group, and assert that sum total matches the
 	// expected value.
-	total, cum := c.Global.TotalInstances, uint(0)
-	for i := range c.Groups {
-		g := c.Groups[i]
-		if g.calculatedInstanceCnt = g.Instances.Count; g.calculatedInstanceCnt == 0 {
-			g.calculatedInstanceCnt = uint(math.Round(g.Instances.Percentage * float64(total)))
+	totalInstances := c.Global.TotalInstances
+
+	computedTotal := uint(0)
+	for _, g := range c.Groups {
+		// When a percentage is specified, we require that totalInstances is set
+		if g.Instances.Percentage > 0 && totalInstances == 0 {
+			return fmt.Errorf("groups count percentage requires a total_instance configuration")
 		}
-		cum += g.calculatedInstanceCnt
+
+		// Update the group's calculated instance counts.
+		if g.calculatedInstanceCnt = g.Instances.Count; g.calculatedInstanceCnt == 0 {
+			g.calculatedInstanceCnt = uint(math.Round(g.Instances.Percentage * float64(totalInstances)))
+		}
+		computedTotal += g.calculatedInstanceCnt
 	}
 
-	if total != cum {
-		return fmt.Errorf("sum of calculated instances per group doesn't match total; total=%d, calculated=%d", total, cum)
+	// Verify the sum total matches the expected value if it was passed.
+	if totalInstances > 0 && totalInstances != computedTotal {
+		return fmt.Errorf("sum of calculated instances per group doesn't match total; total=%d, calculated=%d", totalInstances, computedTotal)
 	}
+
+	c.Global.TotalInstances = computedTotal
 
 	return c.Groups.Validate(c)
 }

--- a/pkg/api/composition.go
+++ b/pkg/api/composition.go
@@ -61,6 +61,10 @@ type Global struct {
 	// this composition; it is the sum of all instances in all groups.
 	TotalInstances uint `toml:"total_instances" json:"total_instances" validate:"gte=0"`
 
+	// ConcurrentBuilds defines the maximum number of concurrent builds that are
+	// scheduled for this test.
+	ConcurrentBuilds int `toml:"concurrent_builds" json:"concurrent_builds"`
+
 	// Builder is the builder we're using.
 	Builder string `toml:"builder" json:"builder"`
 

--- a/pkg/build/docker_generic.go
+++ b/pkg/build/docker_generic.go
@@ -47,9 +47,6 @@ func (b *DockerGenericBuilder) Build(ctx context.Context, in *api.BuildInput, ow
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Minute)
-	defer cancel()
-
 	planPath := cfg.Path
 	basePathForPlan := path.Join("/plan", planPath)
 

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -185,10 +185,6 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 		if cfg.FreshGomod {
 			return nil, fmt.Errorf("fresh_gomod option is not supported when a custom modfile is used")
 		}
-		if cfg.Path != "" {
-			return nil, fmt.Errorf("custom path option is not supported when a custom modfile is used")
-		}
-
 		modfile = cfg.Modfile
 
 		modfileName := strings.TrimSuffix(cfg.Modfile, filepath.Ext(cfg.Modfile))

--- a/pkg/cmd/build.go
+++ b/pkg/cmd/build.go
@@ -114,15 +114,17 @@ var BuildCommand = cli.Command{
 }
 
 func buildCompositionCmd(c *cli.Context) (err error) {
-	comp := new(api.Composition)
 	file := c.String("file")
 	if file == "" {
 		return fmt.Errorf("no composition file supplied")
 	}
 
-	if _, err = toml.DecodeFile(file, comp); err != nil {
-		return fmt.Errorf("failed to process composition file: %w", err)
+	comp, err := loadComposition(file)
+
+	if err != nil {
+		return fmt.Errorf("failed to load composition file: %w", err)
 	}
+
 	if err = comp.ValidateForBuild(); err != nil {
 		return fmt.Errorf("invalid composition file: %w", err)
 	}

--- a/pkg/cmd/fixtures/templates/missing-ressource.toml
+++ b/pkg/cmd/fixtures/templates/missing-ressource.toml
@@ -1,0 +1,13 @@
+[metadata]
+  name = "experiment"
+
+[global]
+  plan = "plan"
+  case = "case"
+  builder = "docker:go"
+  runner = "local:docker"
+
+{{ with (load_resource "./something.toml" ) }}
+  [[failures]]
+  expected = true
+{{ end }}

--- a/pkg/cmd/fixtures/templates/resource-complex.toml
+++ b/pkg/cmd/fixtures/templates/resource-complex.toml
@@ -1,0 +1,23 @@
+# this is a list of instances we can load from a composition.
+[master]
+go_version = '1.18'
+modfile = "go.v0.21.mod"
+selector = 'v0.21'
+
+[custom]
+id = "custom"
+go_version = '1.18'
+modfile = "go.v0.21.mod"
+selector = 'v0.21'
+
+[[groups]]
+id = "v0.11"
+go_version = '1.14'
+modfile = "go.v0.11.mod"
+selector = 'v0.11'
+
+[[groups]]
+id = "v0.17"
+go_version = '1.16'
+modfile = "go.v0.17.mod"
+selector = 'v0.17'

--- a/pkg/cmd/fixtures/templates/resource.toml
+++ b/pkg/cmd/fixtures/templates/resource.toml
@@ -1,0 +1,3 @@
+go_version = '1.18'
+modfile = "go.v0.21.mod"
+selector = 'v0.21'

--- a/pkg/cmd/fixtures/templates/with-resource-complex.toml
+++ b/pkg/cmd/fixtures/templates/with-resource-complex.toml
@@ -1,0 +1,48 @@
+[metadata]
+  name = "experiment"
+
+[global]
+  plan = "plan"
+  case = "case"
+  builder = "docker:go"
+  runner = "local:docker"
+
+{{ with (load_resource "./resource-complex.toml" ) }}
+{{- range .groups }}
+[[groups]]
+  id = "{{ .id }}"
+  instances = { count = 1 }
+
+  [groups.build]
+    selectors = ['{{ .selector }}']
+
+  [groups.build_config]
+    build_base_image = 'golang:{{ .go_version }}-buster'
+    modfile = "{{ .modfile }}"
+{{ end }}
+
+  {{- with .master }}
+[[groups]]
+  id = "master"
+  instances = { count = 1 }
+
+  [groups.build]
+    selectors = ['{{ .selector }}']
+
+    [[groups.build.dependencies]]
+      module = "github.com/libp2p/go-libp2p"
+      version = "master"
+
+  [groups.build_config]
+    build_base_image = 'golang:{{ .go_version }}-buster'
+    modfile = "{{ .modfile }}"
+
+  [groups.build_config.dockerfile_extensions]
+    # deal with dependency changes in master until we create the new vx.y.z instance
+    pre_build = """
+RUN cd ${PLAN_DIR} && \
+    go mod download github.com/libp2p/go-libp2p && \
+    go mod tidy -compat={{ .go_version }}
+"""
+{{- end -}}
+{{- end -}}

--- a/pkg/cmd/fixtures/templates/with-resource-complex.toml.expected
+++ b/pkg/cmd/fixtures/templates/with-resource-complex.toml.expected
@@ -1,0 +1,54 @@
+[metadata]
+  name = "experiment"
+
+[global]
+  plan = "plan"
+  case = "case"
+  builder = "docker:go"
+  runner = "local:docker"
+
+
+[[groups]]
+  id = "v0.11"
+  instances = { count = 1 }
+
+  [groups.build]
+    selectors = ['v0.11']
+
+  [groups.build_config]
+    build_base_image = 'golang:1.14-buster'
+    modfile = "go.v0.11.mod"
+
+[[groups]]
+  id = "v0.17"
+  instances = { count = 1 }
+
+  [groups.build]
+    selectors = ['v0.17']
+
+  [groups.build_config]
+    build_base_image = 'golang:1.16-buster'
+    modfile = "go.v0.17.mod"
+
+[[groups]]
+  id = "master"
+  instances = { count = 1 }
+
+  [groups.build]
+    selectors = ['v0.21']
+
+    [[groups.build.dependencies]]
+      module = "github.com/libp2p/go-libp2p"
+      version = "master"
+
+  [groups.build_config]
+    build_base_image = 'golang:1.18-buster'
+    modfile = "go.v0.21.mod"
+
+  [groups.build_config.dockerfile_extensions]
+    # deal with dependency changes in master until we create the new vx.y.z instance
+    pre_build = """
+RUN cd ${PLAN_DIR} && \
+    go mod download github.com/libp2p/go-libp2p && \
+    go mod tidy -compat=1.18
+"""

--- a/pkg/cmd/fixtures/templates/with-resource.toml
+++ b/pkg/cmd/fixtures/templates/with-resource.toml
@@ -1,0 +1,21 @@
+[metadata]
+  name = "experiment"
+
+[global]
+  plan = "plan"
+  case = "case"
+  builder = "docker:go"
+  runner = "local:docker"
+
+{{ with (load_resource "./resource.toml" ) -}}
+[[groups]]
+  id = "simple"
+  instances = { count = 1 }
+
+  [groups.build]
+    selectors = ['{{ .selector }}']
+
+  [groups.build_config]
+    build_base_image = 'golang:{{ .go_version }}-buster'
+    modfile = "{{ .modfile }}"
+{{- end -}}

--- a/pkg/cmd/fixtures/templates/with-resource.toml.expected
+++ b/pkg/cmd/fixtures/templates/with-resource.toml.expected
@@ -1,0 +1,19 @@
+[metadata]
+  name = "experiment"
+
+[global]
+  plan = "plan"
+  case = "case"
+  builder = "docker:go"
+  runner = "local:docker"
+
+[[groups]]
+  id = "simple"
+  instances = { count = 1 }
+
+  [groups.build]
+    selectors = ['v0.21']
+
+  [groups.build_config]
+    build_base_image = 'golang:1.18-buster'
+    modfile = "go.v0.21.mod"

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -1,15 +1,12 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
-	"text/template"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/testground/testground/pkg/api"
@@ -129,50 +126,6 @@ var RunCommand = cli.Command{
 			),
 		},
 	},
-}
-
-type compositionData struct {
-	Env map[string]string
-}
-
-func loadComposition(file string) (*api.Composition, error) {
-	fdata, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, err
-	}
-
-	data := &compositionData{Env: map[string]string{}}
-
-	// Build a map of environment variables
-	for _, v := range os.Environ() {
-		s := strings.SplitN(v, "=", 2)
-		data.Env[s[0]] = s[1]
-	}
-
-	f := template.FuncMap{
-		"split": func(xs string) []string {
-			return strings.Split(xs, ",")
-		},
-	}
-
-	// Parse and run the composition as a template
-	tpl, err := template.New("tpl").Funcs(f).Parse(string(fdata))
-	if err != nil {
-		return nil, err
-	}
-	buff := &bytes.Buffer{}
-	err = tpl.Execute(buff, data)
-	if err != nil {
-		return nil, err
-	}
-
-	comp := new(api.Composition)
-
-	if _, err = toml.Decode(buff.String(), comp); err != nil {
-		return nil, fmt.Errorf("failed to process composition file: %w", err)
-	}
-
-	return comp, nil
 }
 
 func runCompositionCmd(c *cli.Context) (err error) {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -155,8 +155,14 @@ func runCompositionCmd(c *cli.Context) (err error) {
 		data.Env[s[0]] = s[1]
 	}
 
+	f := template.FuncMap{
+		"split": func(xs string) []string {
+			return strings.Split(xs, ",")
+		},
+	}
+
 	// Parse and run the composition as a template
-	tpl, err := template.New("tpl").Parse(string(fdata))
+	tpl, err := template.New("tpl").Funcs(f).Parse(string(fdata))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/testground/testground/pkg/api"
+
+	"github.com/BurntSushi/toml"
+)
+
+type compositionData struct {
+	Env map[string]string
+}
+
+func loadComposition(file string) (*api.Composition, error) {
+	fdata, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	data := &compositionData{Env: map[string]string{}}
+
+	// Build a map of environment variables
+	for _, v := range os.Environ() {
+		s := strings.SplitN(v, "=", 2)
+		data.Env[s[0]] = s[1]
+	}
+
+	f := template.FuncMap{
+		"split": func(xs string) []string {
+			return strings.Split(xs, ",")
+		},
+	}
+
+	// Parse and run the composition as a template
+	tpl, err := template.New("tpl").Funcs(f).Parse(string(fdata))
+	if err != nil {
+		return nil, err
+	}
+	buff := &bytes.Buffer{}
+	err = tpl.Execute(buff, data)
+	if err != nil {
+		return nil, err
+	}
+
+	comp := new(api.Composition)
+
+	if _, err = toml.Decode(buff.String(), comp); err != nil {
+		return nil, fmt.Errorf("failed to process composition file: %w", err)
+	}
+
+	return comp, nil
+}

--- a/pkg/cmd/template.go
+++ b/pkg/cmd/template.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -17,24 +17,35 @@ type compositionData struct {
 	Env map[string]string
 }
 
-func loadComposition(file string) (*api.Composition, error) {
-	fdata, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, err
-	}
-
-	data := &compositionData{Env: map[string]string{}}
-
-	// Build a map of environment variables
-	for _, v := range os.Environ() {
-		s := strings.SplitN(v, "=", 2)
-		data.Env[s[0]] = s[1]
-	}
+func compileCompositionTemplate(path string, input *compositionData) (*bytes.Buffer, error) {
+	templateDir := filepath.Dir(path)
 
 	f := template.FuncMap{
 		"split": func(xs string) []string {
 			return strings.Split(xs, ",")
 		},
+		"load_resource": func(p string) (map[string]interface{}, error) {
+			// NOTE: we do not worry about path that are leaving the template folders, or going through symlinks
+			//		 because this is run on the client.
+			fullPath := filepath.Join(templateDir, p)
+
+			data, err := os.ReadFile(fullPath)
+			if err != nil {
+				return nil, err
+			}
+
+			var result map[string]interface{}
+			if _, err := toml.Decode(string(data), &result); err != nil {
+				return nil, fmt.Errorf("load_resource %s failed: %w", p, err)
+			}
+
+			return result, nil
+		},
+	}
+
+	fdata, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
 	}
 
 	// Parse and run the composition as a template
@@ -43,13 +54,29 @@ func loadComposition(file string) (*api.Composition, error) {
 		return nil, err
 	}
 	buff := &bytes.Buffer{}
-	err = tpl.Execute(buff, data)
+	err = tpl.Execute(buff, input)
 	if err != nil {
 		return nil, err
 	}
 
-	comp := new(api.Composition)
+	return buff, nil
+}
 
+func loadComposition(path string) (*api.Composition, error) {
+	data := &compositionData{Env: map[string]string{}}
+
+	// Build a map of environment variables
+	for _, v := range os.Environ() {
+		s := strings.SplitN(v, "=", 2)
+		data.Env[s[0]] = s[1]
+	}
+
+	buff, err := compileCompositionTemplate(path, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process composition template: %w", err)
+	}
+
+	comp := new(api.Composition)
 	if _, err = toml.Decode(buff.String(), comp); err != nil {
 		return nil, fmt.Errorf("failed to process composition file: %w", err)
 	}

--- a/pkg/cmd/template_test.go
+++ b/pkg/cmd/template_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	withResource        = "fixtures/templates/with-resource.toml"
+	withResourceComplex = "fixtures/templates/with-resource-complex.toml"
+	missingResource     = "fixtures/templates/missing-resource.toml"
+)
+
+func loadExpected(basePath string) (string, error) {
+	data, err := os.ReadFile(basePath + ".expected")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func TestLoadCompositionWithResourcesGenerateTemplate(t *testing.T) {
+	input := &compositionData{Env: map[string]string{}}
+	buff, err := compileCompositionTemplate(withResource, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	str := buff.String()
+	expected, err := loadExpected(withResource)
+
+	require.Nil(t, err)
+	require.Equal(t, expected, str)
+}
+
+func TestLoadCompositionWithResourcesComplexGenerateTemplate(t *testing.T) {
+	input := &compositionData{Env: map[string]string{}}
+	buff, err := compileCompositionTemplate(withResourceComplex, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	str := buff.String()
+	expected, err := loadExpected(withResourceComplex)
+
+	require.Nil(t, err)
+	require.Equal(t, expected, str)
+}
+
+func TestLoadCompositionWithMissingResourcesFail(t *testing.T) {
+	input := &compositionData{Env: map[string]string{}}
+	buff, err := compileCompositionTemplate(missingResource, input)
+
+	require.Error(t, err)
+	require.Nil(t, buff)
+}

--- a/pkg/engine/supervisor.go
+++ b/pkg/engine/supervisor.go
@@ -340,7 +340,6 @@ func (e *Engine) doBuild(ctx context.Context, input *BuildInput, ow *rpc.OutputW
 		// no need to synchronise access, as each goroutine will write its
 		// response in its index.
 		ress   = make([]*api.BuildOutput, len(comp.Groups))
-		errgrp = errgroup.Group{}
 		cancel context.CancelFunc
 	)
 
@@ -386,6 +385,14 @@ func (e *Engine) doBuild(ctx context.Context, input *BuildInput, ow *rpc.OutputW
 	// Trigger a build job for each unique build, and wait until all of them are
 	// done, mapping the build artifacts back to the original group positions in
 	// the response.
+	errGroup, errGroupCtx := errgroup.WithContext(ctx)
+
+	concurrentBuilds := comp.Global.ConcurrentBuilds
+	if concurrentBuilds == 0 {
+		concurrentBuilds = -1
+	}
+	errGroup.SetLimit(concurrentBuilds)
+
 	var cnt int
 	for key, idxs := range uniq {
 		idxs := idxs
@@ -394,7 +401,7 @@ func (e *Engine) doBuild(ctx context.Context, input *BuildInput, ow *rpc.OutputW
 		src := finalSources[cnt]
 		cnt++
 
-		errgrp.Go(func() (err error) {
+		errGroup.Go(func() (err error) {
 			// Every Group in `idxs`` have the same build key. They are identitical when it comes to build,
 			// so it's safe to use the first one to build them all.
 			grp := comp.Groups[idxs[0]]
@@ -450,7 +457,7 @@ func (e *Engine) doBuild(ctx context.Context, input *BuildInput, ow *rpc.OutputW
 				UnpackedSources: src,
 			}
 
-			res, err := bm.Build(ctx, in, ow)
+			res, err := bm.Build(errGroupCtx, in, ow)
 			if err != nil {
 				ow.Infow("build failed", "plan", plan, "groups", grpids, "builder", builder, "error", err)
 				return err
@@ -470,7 +477,7 @@ func (e *Engine) doBuild(ctx context.Context, input *BuildInput, ow *rpc.OutputW
 	}
 
 	// Wait until all goroutines are done. If any failed, return the error.
-	if err := errgrp.Wait(); err != nil {
+	if err := errGroup.Wait(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
- [x] Introduce `split` operation in composition templates
- [x] Add a `load_resource` operation in composition templates
  - This lets a user define configuration in a file (like a list of instances) and use them during composition templating.
- [x] drop arbitrary build timeout (we have a task timeout)
- [x] drop instance count requirements when we can deduce it
- [x] provide composition templating during `build` (it was only applied during `run` before)
- [x] Add a concurrency option to build artifacts one by one
  - When working on rust interop tests, I noticed we lose the benefits of docker caching & explodes storage requirements because we start every build at the same time.