### PR TITLE
Force --wait when caller passes --collect

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -188,7 +188,8 @@ func run(c *cli.Context, comp *api.Composition) (err error) {
 	var (
 		sdkDir    string
 		extraSrcs []string
-		wait      = c.Bool("wait")
+		collectOpt = c.Bool("collect")
+		wait      = c.Bool("wait") || collectOpt // we always wait if we are collecting.
 	)
 
 	if len(buildIdx) > 0 {
@@ -296,8 +297,7 @@ func run(c *cli.Context, comp *api.Composition) (err error) {
 
 	logging.S().Infof("finished run with ID: %s", id)
 
-	// if the `collect` flag is not set, we are done
-	collectOpt := c.Bool("collect")
+	// if the `collect` flag is not set, we are done	
 	if !collectOpt {
 		return data.IsTaskOutcomeInError(&tsk)
 	}


### PR DESCRIPTION
Based on the public [documentation](https://docs.testground.ai/analyzing-the-results#how-to-collect-testground-outputs), testground should wait for the result when `--collect` flag is set, but this is not the case today as `--wait` has to be passed as well.

While we can fix the documentation to be consistent with today's behaviour and have users set both `--wait --collect` flags, it makes more sense to assume the user wants to _wait_ for the collection of result if they only pass `--collect`

**Testing**
Scenario 1: No Wait and No Collect
```
→ testground run single --plan bacalhau \
                        --testcase ping \
                        --builder exec:go \
                        --runner local:exec \
                        --instances 1
Aug 31 16:35:36.035436	INFO	created a synthetic composition file for this job; all instances will run under singleton group "single"
Aug 31 16:35:36.035485	INFO	using home directory: /Users/walid/testground
Aug 31 16:35:36.036025	INFO	no .env.toml found at /Users/walid/testground/.env.toml; running with defaults
Aug 31 16:35:36.036030	INFO	testground client initialized	{"addr": "http://localhost:8042"}

>>> Result:

Aug 31 16:35:36.064930	INFO	run is queued with ID: cc7orm43r49h65h3m3ag
```


Scenario 2: Wait and No Collect
```
→ testground run single --plan bacalhau \
                        --testcase ping \
                        --builder exec:go \
                        --runner local:exec \
                        --instances 1 --wait
Aug 31 16:40:32.206811	INFO	created a synthetic composition file for this job; all instances will run under singleton group "single"
Aug 31 16:40:32.206845	INFO	using home directory: /Users/walid/testground
Aug 31 16:40:32.206864	INFO	no .env.toml found at /Users/walid/testground/.env.toml; running with defaults
Aug 31 16:40:32.206866	INFO	testground client initialized	{"addr": "http://localhost:8042"}

>>> Result:

Aug 31 16:40:32.229868	INFO	run is queued with ID: cc7ou043r49h65h3m3b0

>>> Server output:

Aug 31 16:40:32.688622	INFO	...
...
Aug 31 16:40:34.096049	INFO	0.2415s    MESSAGE << single[000] >> Hello, World.
Aug 31 16:40:34.096065	INFO	0.2415s         OK << single[000] >>
Aug 31 16:40:34.129965	INFO	run finished with outcome unknown	{"run_id": "cc7ou043r49h65h3m3b0", "plan": "plan1", "case": "ping", "runner": "local:exec", "instances": 1}

>>> Result:

Aug 31 16:40:36.741253	INFO	finished run with ID: cc7ou043r49h65h3m3b0
```


Scenario 3: Collect without Wait
```
→ testground run single --plan bacalhau \
                        --testcase ping \
                        --builder exec:go \
                        --runner local:exec \
                        --instances 1 --collect
Aug 31 16:41:01.277367	INFO	created a synthetic composition file for this job; all instances will run under singleton group "single"
Aug 31 16:41:01.277405	INFO	using home directory: /Users/walid/testground
Aug 31 16:41:01.277424	INFO	no .env.toml found at /Users/walid/testground/.env.toml; running with defaults
Aug 31 16:41:01.277426	INFO	testground client initialized	{"addr": "http://localhost:8042"}

>>> Result:

Aug 31 16:41:01.292096	INFO	run is queued with ID: cc7ou7c3r49h65h3m3bg

>>> Server output:

Aug 31 16:41:02.100909	INFO	...
...
Aug 31 16:41:03.373192	INFO	0.1680s    MESSAGE << single[000] >> Hello, World.
Aug 31 16:41:03.373211	INFO	0.1680s         OK << single[000] >>
Aug 31 16:41:03.411172	INFO	run finished with outcome unknown	{"run_id": "cc7ou7c3r49h65h3m3bg", "plan": "plan1", "case": "ping", "runner": "local:exec", "instances": 1}

>>> Result:

Aug 31 16:41:06.309179	INFO	finished run with ID: cc7ou7c3r49h65h3m3bg

>>> Result:

Aug 31 16:41:06.314255	INFO	created file: cc7ou7c3r49h65h3m3bg.tgz
```

Scenario 4: Collect AND wait
```
→ testground run single --plan bacalhau \
                        --testcase ping \
                        --builder exec:go \
                        --runner local:exec \
                        --instances 1 --collect --wait
Aug 31 16:42:09.011124	INFO	created a synthetic composition file for this job; all instances will run under singleton group "single"
Aug 31 16:42:09.011162	INFO	using home directory: /Users/walid/testground
Aug 31 16:42:09.011181	INFO	no .env.toml found at /Users/walid/testground/.env.toml; running with defaults
Aug 31 16:42:09.011183	INFO	testground client initialized	{"addr": "http://localhost:8042"}

>>> Result:

Aug 31 16:42:09.026869	INFO	run is queued with ID: cc7ouoc3r49h65h3m3c0

>>> Server output:

Aug 31 16:42:09.232980	INFO	...
...
Aug 31 16:42:10.629872	INFO	0.2318s    MESSAGE << single[000] >> Hello, World.
Aug 31 16:42:10.629944	INFO	0.2319s         OK << single[000] >>
Aug 31 16:42:10.665120	INFO	run finished with outcome unknown	{"run_id": "cc7ouoc3r49h65h3m3c0", "plan": "plan1", "case": "ping", "runner": "local:exec", "instances": 1}

>>> Result:

Aug 31 16:42:13.544056	INFO	finished run with ID: cc7ouoc3r49h65h3m3c0

>>> Result:

Aug 31 16:42:13.546416	INFO	created file: cc7ouoc3r49h65h3m3c0.tgz
```
