### PR TITLE
#1293: Engine cleans up processing tasks on startup

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -39,6 +39,12 @@ func New(cfg *config.EnvConfig) (srv *Daemon, err error) {
 		return nil, err
 	}
 
+	// cleanup tasks on startup
+	err = engine.CleanUpTasks()
+	if err != nil {
+		return nil, err
+	}
+
 	mv, err := metrics.NewViewer(cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/testground/testground/pkg/api"
+	"github.com/testground/testground/pkg/config"
 	"github.com/testground/testground/pkg/task"
 )
 
@@ -95,4 +97,64 @@ func TestUnmarshalTaskBuild(t *testing.T) {
 	if !reflect.DeepEqual(newTask, taskData) {
 		t.Errorf("Unmarshal Build task returned incorrect data")
 	}
+}
+
+func TestEngineCleanupTask(t *testing.T) {
+	daemonConfig := config.DaemonConfig{Scheduler: config.SchedulerConfig{TaskRepoType: "memory"}}
+	envConfig := &config.EnvConfig{Daemon: daemonConfig}
+	engineConfig := EngineConfig{EnvConfig: envConfig}
+	e, err := NewEngine(&engineConfig)
+	if err != nil {
+		t.Error(err)
+	}
+
+	inmem := e.store
+
+	// Add tasks to storage
+	// First task: in processing (but no signal connected)
+	id1 := "bt4brhjpc98qra498sg0"
+	tsk1 := &task.Task{ID: id1, Type: task.TypeBuild}
+	tsk1.States = append(tsk1.States, task.DatedState{Created: time.Now(), State: task.StateProcessing})
+	err = inmem.PersistProcessing(tsk1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Second: scheduled
+	id2 := "bt4brhjpc98qra498sg1"
+	tsk2 := &task.Task{ID: id2, Type: task.TypeBuild}
+	tsk2.States = append(tsk2.States, task.DatedState{Created: time.Now(), State: task.StateScheduled})
+	err = inmem.PersistScheduled(tsk2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Third: in processing, with a connected signal
+	id3 := "bt4brhjpc98qra498sg2"
+	tsk3 := &task.Task{ID: id3, Type: task.TypeBuild}
+	tsk3.States = append(tsk3.States, task.DatedState{Created: time.Now(), State: task.StateProcessing})
+	err = inmem.PersistProcessing(tsk3)
+	if err != nil {
+		t.Error(err)
+	}
+
+	task3ch := make(chan int)
+	e.addSignal(id3, task3ch)
+
+	err = e.CleanUpTasks()
+	if err != nil {
+		t.Error(err)
+	}
+
+	tasks, err := e.store.AllTasks()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// 2 tasks should remain
+	assert.Equal(t, 2, len(tasks))
+
+	// the scheduled, and the one in active processing
+	assert.Equal(t, id2, tasks[1].ID)
+	assert.Equal(t, id3, tasks[0].ID)
 }

--- a/pkg/engine/supervisor.go
+++ b/pkg/engine/supervisor.go
@@ -44,6 +44,11 @@ func (e *Engine) deleteSignal(id string) {
 	e.signalsLk.Unlock()
 }
 
+func (e *Engine) hasSignal(id string) bool {
+	_, hasKey := e.signals[id]
+	return hasKey
+}
+
 func (e *Engine) worker(n int) {
 	logging.S().Infow("supervisor worker started", "worker_id", n)
 

--- a/pkg/task/storage.go
+++ b/pkg/task/storage.go
@@ -230,6 +230,29 @@ func (s *Storage) rangeIter(prefix string, start time.Time, end time.Time) (task
 	return tasks, nil
 }
 
+// AllTasks returns all tasks in the store
+func (s *Storage) AllTasks() (tasks []*Task, err error) {
+	rng := util.Range{
+		Start: nil, Limit: nil,
+	}
+
+	tasks = make([]*Task, 0)
+
+	iter := s.db.NewIterator(&rng, nil)
+	defer iter.Release()
+
+	for iter.Next() {
+		tsk := &Task{}
+
+		err := json.Unmarshal(iter.Value(), tsk)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, tsk)
+	}
+	return tasks, nil
+}
+
 func NewMemoryTaskStorage() (*Storage, error) {
 	inmem := storage.NewMemStorage()
 	db, err := leveldb.Open(inmem, nil)


### PR DESCRIPTION

Fixes #1293 .

The engine will clean up tasks in the `Processing` state on startup. I've been trying to come up with the best way to limit the use of this function to the daemon startup:
 - Make the function private, and call it in the `New`, when the engine is created. I don't like adding too many steps to initialization / constructors, so I went with option two:
 - Make the function public, and call it from the daemon, when the engine is created. 
 
 As a safeguard (to prevent undesired side-effects), the engine will skip tasks for which a signal channel exists - these tasks are being actively processed, and should not be deleted.
 
Please let me if my reasoning is correct, thank you!