### PR TITLE
Support replacing  modules with local paths

### DIFF
--- a/pkg/api/builder.go
+++ b/pkg/api/builder.go
@@ -78,5 +78,13 @@ type DependencyTarget struct {
 	Target string
 
 	// Version is the version of the dependency we want to use.
+	//It can be optional for local targets.
 	Version string
+}
+
+func (target DependencyTarget) String() string {
+	if target.Version == "" {
+		return target.Target
+	}
+	return target.Target + "@" + target.Version
 }

--- a/pkg/build/docker_go.go
+++ b/pkg/build/docker_go.go
@@ -225,7 +225,7 @@ func (b *DockerGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc
 		if ver.Target == "" {
 			ver.Target = mod
 		}
-		replaces = append(replaces, fmt.Sprintf("-replace=%s=%s@%s", mod, ver.Target, ver.Version))
+		replaces = append(replaces, fmt.Sprintf("-replace=%s=%s", mod, ver))
 	}
 
 	// Inject replace directives for the SDK modules.

--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -66,7 +66,7 @@ func (b *ExecGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.O
 	// If we have version overrides, apply them.
 	var replaces []string
 	for mod, ver := range in.Dependencies {
-		replaces = append(replaces, fmt.Sprintf("-replace=%s=%s@%s", mod, ver.Target, ver.Version))
+		replaces = append(replaces, fmt.Sprintf("-replace=%s=%s", mod, ver))
 	}
 
 	if sdksrc != "" {

--- a/pkg/cmd/common.go
+++ b/pkg/cmd/common.go
@@ -104,14 +104,17 @@ func createSingletonComposition(c *cli.Context) (*api.Composition, error) {
 
 	for name, target := range deps {
 		parts := strings.Split(target, "@")
-		if (len(parts)) != 2 {
+		version := ""
+		if len(parts) == 2 {
+			version = parts[1]
+		} else if len(parts) > 2 {
 			return nil, fmt.Errorf("invalid target-version: %s", target)
 		}
 
 		dep := api.Dependency{
 			Module:  name,
 			Target:  parts[0],
-			Version: parts[1],
+			Version: version,
 		}
 
 		comp.Groups[0].Build.Dependencies = append(comp.Groups[0].Build.Dependencies, dep)


### PR DESCRIPTION
While testground supports overriding module dependencies through `--deps` argument, it doesn't support overriding with local modules as it currently requires passing a target version which doesn't work with local modules. This prevents using testground to test local changes before merging those local changes.

This PR fixes this by making the version part of the target module as optional

### Testing Before the Fix
```
→ testground run single --plan bacalhau6 --testcase ping  --builder exec:go --runner local:exec  --instances 3 --wait \
 --dep github.com/filecoin-project/bacalhau=/Users/walid/ProtocolLabs/workspace/bacalhau
invalid target-version: /Users/walid/ProtocolLabs/workspace/bacalhau
```

```
→ testground run single --plan bacalhau6 --testcase ping  --builder exec:go --runner local:exec  --instances 3 --wait \
 --dep github.com/filecoin-project/bacalhau=/Users/walid/ProtocolLabs/workspace/bacalhau@latest
/Users/walid/testground/data/work/requests/a764e6ba/plan/go.mod:316: malformed module path "/Users/walid/ProtocolLabs/workspace/bacalhau": empty path element
```

```
→ testground run single --plan bacalhau6 --testcase ping  --builder exec:go --runner local:exec  --instances 3 --wait \
--dep github.com/filecoin-project/bacalhau=/Users/walid/ProtocolLabs/workspace/bacalhau@v0.1.43
/Users/walid/testground/data/work/requests/b1d154e5/plan/go.mod:314: replacement module directory path "/Users/walid/ProtocolLabs/workspace/bacalhau" cannot have version
```

```
→ testground run single --plan bacalhau6 --testcase ping  --builder exec:go --runner local:exec  --instances 3 --wait \
 --dep github.com/filecoin-project/bacalhau=/Users/walid/ProtocolLabs/workspace/bacalhau@      
Sep  7 18:39:50.420195  INFO    build failed    {"plan": "bacalhau", "groups": ["single"], "builder": "exec:go", "error": "unable to add replace directives to go.mod; exit status 1; output: "}
```

### Testing After the Fix

```
→ testground run single --plan bacalhau6 --testcase ping  --builder exec:go --runner local:exec  --instances 3 --wait \
 --dep github.com/filecoin-project/bacalhau=/Users/walid/ProtocolLabs/workspace/bacalhau
Sep  7 20:11:55.057537  INFO    build succeeded {"plan": "bacalhau", "groups": ["single"], "builder": "exec:go", "artifact": "/Users/walid/testground/data/work/exec-go--bacalhau-121bea7191d8"}
```
