### PR TITLE
fix: go dependencies rewrite in exec:go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - This ̀`CHANGELOG.md` file. See [PR 1445]
 
+### Fixed
+- Fix dependencies rewrites in the `exec:go` builder. See [PR 1469]
+
 [PR 1445]: https://github.com/testground/testground/pull/1445
+[PR 1469]: https://github.com/testground/testground/pull/1469

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ test-integ-cluster-k8s:
 
 test-integ-local-exec:
 	./integration_tests/03_exec_go_placebo_ok.sh
+	./integration_tests/20_exec_go_mod_rewrites.sh
 
 test-integ-local-docker:
 	./integration_tests/04_docker_placebo_ok.sh

--- a/integration_tests/20_exec_go_mod_rewrites.sh
+++ b/integration_tests/20_exec_go_mod_rewrites.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+my_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$my_dir/header.sh"
+
+testground plan import --from ./plans --name testground
+
+pushd $TEMPDIR
+
+testground run composition \
+    -f ${my_dir}/../plans/placebo/_compositions/pr-1469-override-dependencies.toml \
+    --collect \
+    --wait | tee run.out
+
+SKIP_LOG_PARSING=true assert_run_output_is_correct run.out
+
+popd
+
+echo "terminating remaining containers"
+testground terminate --runner local:exec

--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -98,7 +98,7 @@ func (b *ExecGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.O
 
 	// Calculate the arguments to go build.
 	// go build -o <output_path> [-tags <comma-separated tags>] <exec_pkg>
-	var args = []string{"build", "-gcflags='all=-N -l'", "-o", path}
+	var args = []string{"build", "-gcflags=all=-N -l", "-o", path}
 	if len(in.Selectors) > 0 {
 		args = append(args, "-tags")
 		args = append(args, strings.Join(in.Selectors, ","))

--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -85,7 +85,7 @@ func (b *ExecGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.O
 	}
 
 	// go mod tidy
-	cmd := exec.CommandContext(ctx, "go", append([]string{"mod", "tidy"})...)
+	cmd := exec.CommandContext(ctx, "go", "mod", "tidy")
 	cmd.Dir = plansrc
 	if err := cmd.Run(); err != nil {
 		out, _ := cmd.CombinedOutput()

--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -84,6 +84,14 @@ func (b *ExecGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.O
 		}
 	}
 
+	// go mod tidy
+	cmd := exec.CommandContext(ctx, "go", append([]string{"mod", "tidy"})...)
+	cmd.Dir = plansrc
+	if err := cmd.Run(); err != nil {
+		out, _ := cmd.CombinedOutput()
+		return nil, fmt.Errorf("unable to go mod tidy in build; %w; output: %s", err, string(out))
+	}
+
 	// Calculate the arguments to go build.
 	// go build -o <output_path> [-tags <comma-separated tags>] <exec_pkg>
 	var args = []string{"build", "-gcflags='all=-N -l'", "-o", path}
@@ -94,7 +102,7 @@ func (b *ExecGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.O
 	args = append(args, cfg.ExecPkg)
 
 	// Execute the build.
-	cmd := exec.CommandContext(ctx, "go", args...)
+	cmd = exec.CommandContext(ctx, "go", args...)
 	cmd.Dir = plansrc
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/build/exec_go.go
+++ b/pkg/build/exec_go.go
@@ -66,6 +66,10 @@ func (b *ExecGoBuilder) Build(ctx context.Context, in *api.BuildInput, ow *rpc.O
 	// If we have version overrides, apply them.
 	var replaces []string
 	for mod, ver := range in.Dependencies {
+		if ver.Target == "" {
+			ver.Target = mod
+		}
+
 		replaces = append(replaces, fmt.Sprintf("-replace=%s=%s@%s", mod, ver.Target, ver.Version))
 	}
 

--- a/plans/placebo/_compositions/pr-1469-override-dependencies.toml
+++ b/plans/placebo/_compositions/pr-1469-override-dependencies.toml
@@ -1,0 +1,18 @@
+[metadata]
+  name = "pr-1469-override-dependencies"
+
+[global]
+  plan = "testground/placebo"
+  case = "ok"
+  runner = "local:exec"
+  builder = "exec:go"
+
+[[groups]]
+  id = "instance"
+  instances = {count = 2}
+
+  [groups.build]
+
+  [[groups.build.dependencies]]
+       module = "github.com/testground/sdk-go"
+       version = "49c90fa754052018b70c63d87b7f1d37f6080a78"

--- a/plans/placebo/go.mod
+++ b/plans/placebo/go.mod
@@ -2,4 +2,8 @@ module github.com/testground/testground/plans/placebo
 
 go 1.16
 
+// Note that this test contains a composition that
+// will test the dependency rewrites. If you change
+// the version here, you probably want to update
+// the composition file.
 require github.com/testground/sdk-go v0.3.1-0.20211012114808-49c90fa75405


### PR DESCRIPTION

I was trying to run a composition that used different dependencies for the different instances using `exec:go`. I was setting the instances' dependencies in the `composition.toml` as follows: 
```toml
[[groups]]
  id = "attacker"
  [groups.build]

  [[groups.build.dependencies]]
       module = "github.com/filecoin-project/lotus"
       version = "8f48631fc48773821fd853b6d9612380b9d74cb4"
```
When running the composition I kept getting the error: `task cancelled due to error     {"err": "task of type run cancelled: unable to add replace directives to go.mod; exit status 1; output: "}`.

Inspecting the code, I realized that the `dependency.Target` had to be set explicitly for it to work with `exec:go`. Modifying the dependency for the instance in the `composition.toml` to the following made it work.
```toml
[[groups]]
  id = "attacker"
  [groups.build]

  [[groups.build.dependencies]]
       module = "github.com/filecoin-project/lotus"
       target = "github.com/filecoin-project/lotus"
       version = "8f48631fc48773821fd853b6d9612380b9d74cb4"
```
However, I was then getting an error when building the assets because after the dependency replacement, we needed a `go mod tidy`. Adding the small command included in this PR completely fixed the issue, and I was able to run the composition with multiple versions seamlessly. 