### PR TITLE
InfluxDB: enable Flux

### DIFF
--- a/pkg/runner/local_common.go
+++ b/pkg/runner/local_common.go
@@ -110,7 +110,7 @@ func localCommonHealthcheck(ctx context.Context, hh *healthcheck.Helper, cli *cl
 			ContainerName: "testground-influxdb",
 			ContainerConfig: &container.Config{
 				Image: "library/influxdb:1.8",
-				Env:   []string{"INFLUXDB_HTTP_AUTH_ENABLED=false", "INFLUXDB_DB=testground"},
+				Env:   []string{"INFLUXDB_HTTP_AUTH_ENABLED=false", "INFLUXDB_DB=testground", "INFLUXDB_HTTP_FLUX_ENABLED=true"},
 			},
 			HostConfig: &container.HostConfig{
 				PortBindings: exposed,


### PR DESCRIPTION
In InfluxDB v1.8, Flux is [disabled by default](https://docs.influxdata.com/influxdb/v1.8/flux/installation/). This PR enables [Flux](https://docs.influxdata.com/influxdb/v1.8/flux/) for `local` runner so we can use the useful features like `histogram()`.