### PR TITLE
Fix SKIP_LOG_PARSING condition

### DIFF
--- a/integration_tests/13_02_docker_builder_configuration.sh
+++ b/integration_tests/13_02_docker_builder_configuration.sh
@@ -13,7 +13,7 @@ testground run composition -f ${my_dir}/../plans/_integrations_interop/_composit
     --collect \
     --wait | tee run.out
 
-assert_run_output_is_correct run.out
+SKIP_LOG_PARSING=true assert_run_output_is_correct run.out
 
 popd
 

--- a/integration_tests/13_docker_builder_configuration.sh
+++ b/integration_tests/13_docker_builder_configuration.sh
@@ -13,7 +13,7 @@ testground run composition -f ${my_dir}/../plans/_integrations_interop/_composit
     --collect \
     --wait | tee run.out
 
-assert_run_output_is_correct run.out
+SKIP_LOG_PARSING=true assert_run_output_is_correct run.out
 
 popd
 

--- a/integration_tests/15_docker_mixed_builders_configuration.sh
+++ b/integration_tests/15_docker_mixed_builders_configuration.sh
@@ -16,7 +16,7 @@ testground run composition -f ${my_dir}/../plans/_integrations_mixed_builders/_c
     --collect \
     --wait | tee run.out
 
-assert_run_output_is_correct run.out
+SKIP_LOG_PARSING=true assert_run_output_is_correct run.out
 
 popd
 

--- a/integration_tests/header.sh
+++ b/integration_tests/header.sh
@@ -61,7 +61,7 @@ function assert_run_output_is_correct {
 
   tar -xzvvf ${RUN_ID}.tgz
 
-  if [ SKIP_LOG_PARSING ]; then
+  if [[ -n "$SKIP_LOG_PARSING" ]]; then
     return
   fi
 


### PR DESCRIPTION
The `if` condition is always true. With the change, the `if` condition is true only when `SKIP_LOG_PARSING` is set to a non-empty string.

``` bash
> echo $SKIP_LOG_PARSING
>
> if [ SKIP_LOG_PARSING ]; then echo "skip"; fi
> skip
> if [[ -n "$SKIP_LOG_PARSING" ]]; then echo "skip"; fi
> SKIP_LOG_PARSING=true
> if [[ -n "$SKIP_LOG_PARSING" ]]; then echo "skip"; fi
> skip
```