### PR TITLE
integration_test: fix interop test 19

### DIFF
--- a/env-kind.toml
+++ b/env-kind.toml
@@ -19,6 +19,7 @@ listen                    = ":8040"
 [daemon.scheduler]
 task_timeout_min          = 5
 task_repo_type            = "disk"
+workers                   = 1
 
 [client]
 endpoint = "http://localhost:8040"

--- a/integration_tests/19_limit_runs_per_branch.sh
+++ b/integration_tests/19_limit_runs_per_branch.sh
@@ -25,11 +25,7 @@ t1=$(testground run single \
     --runner=local:docker \
     --instances=1 \
     --metadata-branch b1 \
-    --metadata-repo r1 \
-    --collect)
-
-# Very unwieldy, $59 is the ID in the log
-run_id1=$(echo $t1 | awk '/run is queued with ID: / {print $59}')
+    --metadata-repo r1)
 
 # Run the second test case, and wait for it to finish
 t2=$(testground run single \
@@ -44,6 +40,8 @@ t2=$(testground run single \
     --wait \
     --collect)
 
+# Very unwieldy, $59 is the ID in the log
+run_id1=$(echo $t1 | awk '/run is queued with ID: / {print $59}')
 run_id2=$(echo $t2 | awk '/run is queued with ID: / {print $59}')
 
 # First run must be canceled


### PR DESCRIPTION

Fix the test introduced in https://github.com/testground/testground/pull/1399 and enabled in https://github.com/testground/testground/pull/1467.

With > 1 runner, both tasks are scheduled at the same time, which means that they are never cancelled (we don't cancel running tasks yet).