### PR TITLE
example-rust: improve test-case:

### DIFF
--- a/plans/example-rust/src/main.rs
+++ b/plans/example-rust/src/main.rs
@@ -1,4 +1,5 @@
-use std::net::{Ipv4Addr, TcpListener, TcpStream};
+use std::net::Ipv4Addr;
+use tokio::net::{TcpListener, TcpStream};
 
 const LISTENING_PORT: u16 = 1234;
 
@@ -7,11 +8,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (client, _run_parameters) = testground::client::Client::new().await?;
     client.wait_network_initialized().await?;
 
-    let local_addr = &if_addrs::get_if_addrs()
-        .unwrap()
+    let local_addr = &if_addrs::get_if_addrs()?
         .into_iter()
         .find(|iface| iface.name == "eth1")
-        .unwrap()
+        .ok_or("Could not find interface eth1")?
         .addr
         .ip();
 
@@ -19,39 +19,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::net::IpAddr::V4(addr) if addr.octets()[3] == 2 => {
             println!("Test instance, listening for incoming connections.");
 
-            let listener = TcpListener::bind((*addr, LISTENING_PORT))?;
+            let listener = TcpListener::bind((*addr, LISTENING_PORT)).await?;
 
             client.signal("listening".to_string()).await?;
 
-            for _stream in listener.incoming() {
-                println!("Established inbound TCP connection.");
-                break;
-            }
+            println!("Established inbound TCP connection.");
+            let _ = listener.accept().await?;
         }
         std::net::IpAddr::V4(addr) if addr.octets()[3] == 3 => {
             println!("Test instance, connecting to listening instance.");
 
-            client
-                .barrier("listening".to_string(), 1)
-                .await?;
+            client.barrier("listening".to_string(), 1).await?;
 
             let remote_addr: Ipv4Addr = {
                 let mut octets = addr.octets();
                 octets[3] = 2;
                 octets.into()
             };
-            let _stream = TcpStream::connect((remote_addr, LISTENING_PORT)).unwrap();
-            println!("Established outbound TCP connection.");
+            let _stream = TcpStream::connect((remote_addr, LISTENING_PORT)).await?;
         }
         addr => {
-            client.record_failure("Unexpected local IP address")
-                .await?;
+            client.record_failure("Unexpected local IP address").await?;
             panic!("Unexpected local IP address {:?}", addr);
         }
     }
 
-    client.record_success()
-        .await?;
+    client.record_success().await?;
     println!("Done!");
     Ok(())
 }

--- a/plans/example-rust/src/main.rs
+++ b/plans/example-rust/src/main.rs
@@ -23,8 +23,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             client.signal("listening".to_string()).await?;
 
-            println!("Established inbound TCP connection.");
             let _ = listener.accept().await?;
+            println!("Established inbound TCP connection.");
         }
         std::net::IpAddr::V4(addr) if addr.octets()[3] == 3 => {
             println!("Test instance, connecting to listening instance.");
@@ -37,6 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 octets.into()
             };
             let _stream = TcpStream::connect((remote_addr, LISTENING_PORT)).await?;
+            println!("Established outbound TCP connection.");
         }
         addr => {
             client.record_failure("Unexpected local IP address").await?;


### PR DESCRIPTION
- use tokio's TcpListener and TcpStream to not block the executor thread.
- remove remaining unwraps.
- cargo fmt