### PR TITLE
doc: add documentation and rollups example to roadmap's vision

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,7 +57,7 @@ Testground As A Service embodies our long-term vision.
 - An easy-to-follow documentation and guidelines for users to jump straight into action,
   - An example: pages that can hand-hold through the learning curve, thus fostering community-driven tutorials. As well as APIs section that can help navigate through the vast possibilities of testground.
 - The ability to experiment with large-scale networks and simplify the integration testing of "any" network-related code,
-  - An example: experiment with a set of rollup networks that deploy their data to a different DA network. A unified/standardised way of doing network(s)-to-network(s) experiments would eliminate a lof of bike-shedding that future teams will go through. 
+  - An example: having the ability to define standard experiments with a set of roll-up networks that deploy their data to a different DA network. This would help teams compare solutions using the same metrics.
 - The ability to track the impact of a change in terms of stability & performance across multiple projects,
   - An example: having the ability to run IPFS benchmarks and simulations with different combinations of libraries. This would help us measure regression and improvements as soon as they occur in upstream dependencies.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,7 +54,10 @@ _This section is still a very high-level draft_
 Testground As A Service embodies our long-term vision.
 
 - A single, scalable, installation that one or more organizations can use in all their projects,
+- An easy-to-follow documentation and guidelines for users to jump straight into action,
+  - An example: pages that can hand-hold through the learning curve, thus fostering community-driven tutorials. As well as APIs section that can help navigate through the vast possibilities of testground.
 - The ability to experiment with large-scale networks and simplify the integration testing of "any" network-related code,
+  - An example: experiment with a set of rollup networks that deploy their data to a different DA network. A unified/standardised way of doing network(s)-to-network(s) experiments would eliminate a lof of bike-shedding that future teams will go through. 
 - The ability to track the impact of a change in terms of stability & performance across multiple projects,
   - An example: having the ability to run IPFS benchmarks and simulations with different combinations of libraries. This would help us measure regression and improvements as soon as they occur in upstream dependencies.
 
@@ -62,6 +65,7 @@ Products with similar ideas but specialized in different areas:
 
 - database: [CockroachDB performance tracker](https://cockroachdb.github.io/pebble/?max=local),
 - browser: [Webkit Performance Dashboard](https://perf.webkit.org/v3/)
+- selenium : [Selenium](https://www.selenium.dev/)
 
 Research and Templates
 


### PR DESCRIPTION
Notes on why imho 3 points should be included in the vision section: 

### Documentation is king for wider adoption

Currently, our documentation is very `todo-list`ish and users(me included back in time) faced harshed realities of implementation for their projects' needs. Async hand-holding is needed as I've heard multiple times that nailing down the concept of testground is not straight-forward and is causing issues like: 
- https://github.com/testground/testground/issues/1336 - compositions are hard to nail down. Especially when a user opens the `runenv` APIs and discovers that there are multiple ways to treat the test-run instance's perspective
- https://github.com/testground/testground/issues/1378 - classic Dunning-Kruger effect that should be populated somewhere in docs that blocking calls should be treated with extra-caution when using sync-service APIs
- https://github.com/testground/testground/issues/1275 - what is results exactly? Somebody can think like me that it's the pass/failure which is not the case 

### Large-scale networks(example for a rollup)

Going forward with the L1-L2-L(N) narrative, it will be beneficial if we think forward what users might need from testground to test their rollups, or even a complete e2e system test, like:
A Button call-> Triggers a smart contract -> state transition in the rollup -> dumps data to a DA Layer. And then we check the new data at the UI level. Now, imagine how many variations we can have for a single test-case (network wise as well as VM, DA, instances count, etc.)

### Selenium/Cypress

Both are golden standards for web-browser automation and I do believe that testground should be a one-stop shop for blockchains' / p2p network testing/experimentation

Ref: #1491 