### PR TITLE
ci: remove hint/needs-author-input when the author comments

### DIFF
--- a/.github/workflows/pr-update-on-author-input.yml
+++ b/.github/workflows/pr-update-on-author-input.yml
@@ -1,0 +1,14 @@
+name: Update PR on author input
+
+on:
+  - issue_comment
+  - pull_request_review_comment
+
+jobs:
+  remove_label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
+        if: github.event.comment.user.id == github.event.issue.user.id || github.event.comment.user.id == github.event.pull_request.user.id
+        with:
+          labels: hint/needs-author-input


### PR DESCRIPTION
Contributes to https://github.com/testground/testground/issues/1511