### PR TITLE
feat: Use XDG Base Directory Specificationfor TESTGROUND_HOME directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `[[runs]]` field to compositions. See [PR 1516]
 - Add `--run-ids` option during `testground run`. See [PR 1516]
 - Add `--result-file ./output.csv` option during `testground run`. See [PR 1516]
+- Move default `TESTGROUND_HOME` from `~/testgraound` to xdg directory specification. See [PR 1544]
 
 ### Fixed
 - Fix dependencies rewrites in the `exec:go` builder. See [PR 1469]
@@ -24,3 +25,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR 1469]: https://github.com/testground/testground/pull/1469
 [PR 1481]: https://github.com/testground/testground/pull/1481
 [PR 1537]: https://github.com/testground/testground/pull/1537
+[PR 1544]: https://github.com/testground/testground/pull/1544

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.4.1
+	github.com/adrg/xdg v0.4.0
 	github.com/aws/aws-sdk-go v1.40.19
 	github.com/containernetworking/cni v1.0.0
 	github.com/docker/docker v1.4.2-0.20200206084213-b5fc6ea92cde
@@ -37,7 +38,6 @@ require (
 	github.com/whilp/git-urls v1.0.0
 	go.uber.org/zap v1.19.0
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
-	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -702,8 +704,8 @@ golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env sh
 set -e
 set -o pipefail
+unameOut="$(uname -s)"
+TESTGROUND_HOME="$HOME/.config/testground"
+case "${unameOut}" in
+    Darwin*)    TESTGROUND_HOME="$HOME/Library/Application Support";;
+esac
 
-mkdir -p ~/testground && cd ~/testground
+mkdir -p "$TESTGROUND_HOME" && cd "$TESTGROUND_HOME"
 
 docker pull iptestground/testground:edge
 docker pull iptestground/sync-service:edge
@@ -12,7 +17,7 @@ docker pull iptestground/sidecar:edge
 docker run -v ${PWD}:/mount --rm --entrypoint cp iptestground/testground:edge /testground /mount/testground
 
 if [ -z $GITHUB_PATH ]; then
-    echo "Testground was installed to ~/testground. Add this to your path."
+    echo "Testground was installed to \"$TESTGROUND_HOME\". Add this to your path."
 else
-    echo "~/testground" >> $GITHUB_PATH
+    echo "$TESTGROUND_HOME" >> $GITHUB_PATH
 fi

--- a/integration_tests/19_limit_runs_per_branch.sh
+++ b/integration_tests/19_limit_runs_per_branch.sh
@@ -40,9 +40,8 @@ t2=$(testground run single \
     --wait \
     --collect)
 
-# Very unwieldy, $59 is the ID in the log
-run_id1=$(echo $t1 | awk '/run is queued with ID: / {print $59}')
-run_id2=$(echo $t2 | awk '/run is queued with ID: / {print $59}')
+run_id1=$(echo "$t1" | awk '/run is queued with ID: / {print $10}')
+run_id2=$(echo "$t2" | awk '/run is queued with ID: / {print $10}')
 
 # First run must be canceled
 assert_testground_task_status "$run_id1" 'canceled'

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -58,9 +58,10 @@ func getDefaultHome() string {
 	fi, err := os.Stat(legacyHomePath)
 	if err == nil && fi.IsDir() {
 		// $HOME/testground detected, use this path to support legacy users
-		logging.S().Warnf("[DEPRECATED] path \"%s\" is deprecated. "+
-			"The default for future releases will be \"%s\". "+
-			"Use \"export TESTGROUND_HOME='%s'\" to override default testground home",
+		logging.S().Warnf("[DEPRECATED] \"%s\" as a default testground home is deprecated. "+
+			"Future releases will use \"%s\" as the default for testground home. "+
+			"If you want to keep using your current testground home, "+
+			"please set it explicitly using \"export TESTGROUND_HOME='%s'\".",
 			legacyHomePath, defaultHomePath, legacyHomePath)
 
 		return legacyHomePath


### PR DESCRIPTION
Having TESTGROUND_HOME directory in `~/testground` pollutes my $HOME. There are standards for application data/cache/config across operating systems, see https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html and https://github.com/adrg/xdg

For linux/unix:
`~/.config/testground`

For Mac/Darwin:

`~/Library/Application Support/testground`