### PR TITLE
local_docker: make it more explicit when a test is killed when reaching a timeout

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [ "docker_examples", "local_exec" ]
+        suite: [ "docker_examples", "local_exec", "local_docker" ]
         os: [ "ubuntu" ]
         go: [ "1.16.x" ]
     env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,6 +21,7 @@ jobs:
       COVERAGES: ""
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     name: "[${{ matrix.suite }}] on ${{ matrix.os }} (go ${{ matrix.go }})"
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/pkg/integration/local_docker_test.go
+++ b/pkg/integration/local_docker_test.go
@@ -1,0 +1,66 @@
+//go:build integration && local_docker
+// +build integration,local_docker
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	. "github.com/testground/testground/pkg/integration/utils"
+)
+
+// fix: stalled tests
+// https://github.com/testground/testground/issues/1542
+func TestPanickingTestWillEndAnyway(t *testing.T) {
+	Setup(t)
+
+	params := RunSingleParams{
+		Plan:      "testground/_integrations",
+		Testcase:  "issue-1542-stalled-test-panic",
+		Builder:   "docker:go",
+		Runner:    "local:docker",
+		Instances: 2,
+		Collect:   true,
+		Wait:      true,
+		DaemonTimeout: 2 * time.Minute,
+	}
+
+	result, err := RunSingle(t, params)
+	defer result.Cleanup()
+
+	require.Error(t, err)
+	require.Equal(t, 1, result.ExitCode)
+	require.NotEmpty(t, result.Stdout)
+
+	RequireOutcomeIsFailure(t, result)
+}
+
+// fix: stalled tests
+// https://github.com/testground/testground/issues/1542
+func TestStalledTestWillEndAnyway(t *testing.T) {
+	Setup(t)
+
+	params := RunSingleParams{
+		Plan:      "testground/_integrations",
+		Testcase:  "issue-1542-stalled-test-stall",
+		Builder:   "docker:go",
+		Runner:    "local:docker",
+		Instances: 2,
+		Collect:   true,
+		Wait:      true,
+		DaemonTimeout: 1 * time.Minute,
+	}
+
+	result, err := RunSingle(t, params)
+	defer result.Cleanup()
+
+	require.Error(t, err)
+	require.Equal(t, 1, result.ExitCode)
+	require.NotEmpty(t, result.Stdout)
+
+	RequireOutcomeIsFailure(t, result)
+
+	require.Contains(t, result.Stdout, "run canceled after reaching the task timeout")
+}

--- a/pkg/integration/utils/daemon.go
+++ b/pkg/integration/utils/daemon.go
@@ -5,22 +5,25 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	"github.com/testground/testground/pkg/config"
 	"github.com/testground/testground/pkg/daemon"
 )
 
-func setupDaemon(t *testing.T) *daemon.Daemon {
+func setupDaemon(t *testing.T, taskTimeout time.Duration) *daemon.Daemon {
 	t.Helper()
 
 	cfg := &config.EnvConfig{
 		Daemon: config.DaemonConfig{
 			Scheduler: config.SchedulerConfig{
 				TaskRepoType: "memory",
+				TaskTimeoutMin: int(taskTimeout.Minutes()),
 			},
 			Listen: "localhost:0",
 		},
 	}
+
 	if err := cfg.EnsureMinimalConfig(); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/integration/utils/entrypoints.go
+++ b/pkg/integration/utils/entrypoints.go
@@ -32,7 +32,7 @@ func RunSingle(t *testing.T, params RunSingleParams) (*RunResult, error) {
 	defer cleanup()
 
 	// Start the daemon
-	srv := setupDaemon(t)
+	srv := setupDaemon(t,  params.DaemonTimeout)
 	defer func() {
 		err := runTerminate(t, srv, params.Runner)
 		srv.Shutdown(context.Background()) //nolint
@@ -104,7 +104,7 @@ func RunComposition(t *testing.T, params RunCompositionParams) (*RunResult, erro
 	defer cleanup()
 
 	// Start the daemon
-	srv := setupDaemon(t)
+	srv := setupDaemon(t, 0)
 	defer func() {
 		err := runTerminate(t, srv, params.Runner)
 		srv.Shutdown(context.Background()) //nolint

--- a/pkg/integration/utils/requires.go
+++ b/pkg/integration/utils/requires.go
@@ -56,6 +56,10 @@ func RequireOutcomeIsFailure(t *testing.T, result *RunResult) {
 	RequireOutcomeIs(t, task.OutcomeFailure, result)
 }
 
+func RequireOutcomeIsCanceled(t *testing.T, result *RunResult) {
+	RequireOutcomeIs(t, task.OutcomeCanceled, result)
+}
+
 // Requires that the folder collected from the run contains
 // some logs and no errors.
 // Assumes it is a single run for a single group.

--- a/pkg/integration/utils/types.go
+++ b/pkg/integration/utils/types.go
@@ -5,17 +5,19 @@ package utils
 
 import (
 	"path/filepath"
+	"time"
 )
 
 type RunSingleParams struct {
-	Plan       string
-	Testcase   string
-	Builder    string
-	Runner     string
-	Instances  int
-	Collect    bool
-	Wait       bool
-	TestParams []string
+	Plan          string
+	Testcase      string
+	Builder       string
+	Runner        string
+	Instances     int
+	Collect       bool
+	Wait          bool
+	TestParams    []string
+	DaemonTimeout time.Duration
 }
 
 type RunCompositionParams struct {
@@ -28,11 +30,11 @@ type RunCompositionParams struct {
 }
 
 type RunResult struct {
-	ExitCode int
-	Stdout   string
-	Stderr   string
+	ExitCode      int
+	Stdout        string
+	Stderr        string
 	CollectFolder string
-	Cleanup func()
+	Cleanup       func()
 }
 
 // (pure method) rewrite the composition parameters to use absolute paths.

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -287,11 +287,19 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 	}
 
 	defer func() {
+		log.Infow("run completed", "err", err)
+
 		if err != nil && result.Outcome == "" {
+			log.Infow("run failed", "err", err)
 			result.Outcome = task.OutcomeFailure
 		}
 		if ctx.Err() == context.Canceled {
-			result.Outcome = task.OutcomeCanceled
+			log.Infow("run canceled")
+			result.Outcome = task.OutcomeFailure
+		}
+		if ctx.Err() == context.DeadlineExceeded {
+			log.Infow("run canceled after reaching the task timeout")
+			result.Outcome = task.OutcomeFailure
 		}
 	}()
 
@@ -633,7 +641,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 				log.Infow("container exited", "id", c.containerID, "group", c.groupID, "group_index", c.groupIdx, "status", status.StatusCode)
 				return nil
 			case <-runGroupCtx.Done(): // race with the group
-				log.Infow("container group exited", runGroupCtx.Err())
+				log.Infow("container group exited", "err", runGroupCtx.Err())
 				return nil
 			}
 		}
@@ -676,7 +684,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 			log.Infow("we timeout'd waiting for outcomes")
 			waitingForOutcomes = false
 		case <-runCtx.Done():
-			log.Infow("the test run ended early")
+			log.Infow("the test run ended early", "err", runCtx.Err())
 			return
 		}
 	}

--- a/pkg/runner/local_docker.go
+++ b/pkg/runner/local_docker.go
@@ -295,7 +295,7 @@ func (r *LocalDockerRunner) Run(ctx context.Context, input *api.RunInput, ow *rp
 		}
 		if ctx.Err() == context.Canceled {
 			log.Infow("run canceled")
-			result.Outcome = task.OutcomeFailure
+			result.Outcome = task.OutcomeCanceled
 		}
 		if ctx.Err() == context.DeadlineExceeded {
 			log.Infow("run canceled after reaching the task timeout")

--- a/plans/_integrations/manifest.toml
+++ b/plans/_integrations/manifest.toml
@@ -21,3 +21,11 @@ instances = { min = 1, max = 1000, default = 1 }
 [[testcases]]
 name = "issue-1493-optional-failure"
 instances = { min = 1, max = 1000, default = 1 }
+
+[[testcases]]
+name = "issue-1542-stalled-test-panic"
+instances = { min = 1, max = 1000, default = 1 }
+
+[[testcases]]
+name = "issue-1542-stalled-test-stall"
+instances = { min = 1, max = 1000, default = 1 }


### PR DESCRIPTION
Relates to #1542
Closes https://github.com/testground/testground/issues/1551

When a job reaches the timeout, it's not very clear that it was canceled.
