### PR TITLE
chore: make install.sh install testground to pwd

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,23 +1,18 @@
 #!/usr/bin/env sh
 set -e
 set -o pipefail
-unameOut="$(uname -s)"
-TESTGROUND_HOME="$HOME/.config/testground"
-case "${unameOut}" in
-    Darwin*)    TESTGROUND_HOME="$HOME/Library/Application Support";;
-esac
-
-mkdir -p "$TESTGROUND_HOME" && cd "$TESTGROUND_HOME"
 
 docker pull iptestground/testground:edge
 docker pull iptestground/sync-service:edge
 docker pull iptestground/sidecar:edge
 
 # At the moment this is the fastest way to get a pre-built testground binary.
-docker run -v ${PWD}:/mount --rm --entrypoint cp iptestground/testground:edge /testground /mount/testground
+id="$(docker create iptestground/testground:edge)"
+docker cp $id:/testground $PWD/testground
+docker rm $id
 
 if [ -z $GITHUB_PATH ]; then
-    echo "Testground was installed to \"$TESTGROUND_HOME\". Add this to your path."
+    echo "Testground was installed to \"$PWD\". Add this to your path."
 else
-    echo "$TESTGROUND_HOME" >> $GITHUB_PATH
+    echo "$PWD" >> $GITHUB_PATH
 fi


### PR DESCRIPTION
I don't think we want to install `testground` binary to `TESTGROUND_HOME`. It seems more obvious to me that `install.sh` would download the binary to the working directory. In that case, the user would be able to easily decide what that should be.

Here's how we could adjust `libp2p/test-plans` afterwards: https://github.com/libp2p/test-plans/compare/test-install-to-pwd?expand=1

And here's this setup part used in a workflow run still working as expected: https://github.com/libp2p/test-plans/actions/runs/3829913805/jobs/6517126745