### PR TITLE
ci: explicitly switch macos build to silicon and upgrade xcode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ commands:
     description: "install go, checkout and restore cache"
     steps:
       - go/install:
-          version: '{{ .Environment.GOVERSION }}'
+          version: "1.16"
       - checkout
 
   setup-install-bins:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,15 @@ parameters:
     type: string
     default: "/home/circleci"
 
+orbs:
+  go: circleci/go@1.7.3
+
 commands:
   setup:
     description: "install go, checkout and restore cache"
     steps:
-      - run:
-          name: "install go"
-          command: |
-            curl --create-dirs -o $GOPATH/go.tar.gz https://dl.google.com/go/go${GOVERSION}.linux-amd64.tar.gz
-            tar --strip-components=1 -C $GOPATH -xzf $GOPATH/go.tar.gz
-            rm -rf $GOPATH/go.tar.gz
+      - go/install:
+          version: "${GOVERSION}"
       - checkout
       - restore_cache:
           keys:
@@ -27,15 +26,8 @@ commands:
   setup-macos:
     description: "install go, checkout and restore cache"
     steps:
-      - run:
-          name: "install go on macOS"
-          command: |
-            brew --version
-            [ ! -d /usr/local/opt/go@1.16 ] && brew install go@1.16 && echo "done installing go"
-            echo 'export GOPATH="$HOME/go"' >> $BASH_ENV
-            echo 'export PATH="/usr/local/opt/go@1.16/bin:$GOPATH/bin:$PATH"' >> $BASH_ENV
-            source $BASH_ENV
-            go version
+      - go/install:
+          version: "${GOVERSION}"
       - checkout
 
   setup-install-bins:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
     description: "install go, checkout and restore cache"
     steps:
       - go/install:
-          version: {{ .Environment.GOVERSION }}
+          version: '{{ .Environment.GOVERSION }}'
       - checkout
       - restore_cache:
           keys:
@@ -27,7 +27,7 @@ commands:
     description: "install go, checkout and restore cache"
     steps:
       - go/install:
-          version: {{ .Environment.GOVERSION }}
+          version: '{{ .Environment.GOVERSION }}'
       - checkout
 
   setup-install-bins:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,8 @@ jobs:
 
   build-macos:
     macos:
-      xcode: 13.2.0
+      xcode: 15.0.0
+    resource_class: macos.x86.medium.gen2
     steps:
       - setup-macos
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 parameters:
   go-version:
     type: string
-    default: "1.16"
+    default: "1.18"
   workspace-dir:
     type: string
     default: "/home/circleci"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 parameters:
   go-version:
     type: string
-    default: "1.18"
+    default: "1.16"
   workspace-dir:
     type: string
     default: "/home/circleci"
@@ -17,7 +17,7 @@ commands:
     description: "install go, checkout and restore cache"
     steps:
       - go/install:
-          version: "${GOVERSION}"
+          version: {{ .Environment.GOVERSION }}
       - checkout
       - restore_cache:
           keys:
@@ -27,7 +27,7 @@ commands:
     description: "install go, checkout and restore cache"
     steps:
       - go/install:
-          version: "${GOVERSION}"
+          version: {{ .Environment.GOVERSION }}
       - checkout
 
   setup-install-bins:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
     description: "install go, checkout and restore cache"
     steps:
       - go/install:
-          version: $GOVERSION
+          version: "1.16"
       - checkout
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
     description: "install go, checkout and restore cache"
     steps:
       - go/install:
-          version: '{{ .Environment.GOVERSION }}'
+          version: $GOVERSION
       - checkout
       - restore_cache:
           keys:


### PR DESCRIPTION
CircleCI is removing support for Apple Intel executors on Oct 2 - see https://discuss.circleci.com/t/macos-resource-deprecation-update/46891. After that date only Apple Silicon executors will be available. This PR ensures the macos builds are executed on Apple Silicon executors only.

FYI, I hardcoded the Go version in the pipeline because something was off with env var substitution. This should be updated if testground is under active development again.