### PR TITLE
ci: use gen2 macos executors explicitly and upgrade xcode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,8 @@ jobs:
 
   build-macos:
     macos:
-      xcode: 13.2.0
+      xcode: 13.4.1
+    resource_class: macos.x86.medium.gen2
     steps:
       - setup-macos
       - run:


### PR DESCRIPTION
This PR ensure the repo continues to build on Apple Intel executors beyond October 2. Gen 1 executors are getting deprecated. See https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718.

In January 2024, Apple Intel executors will be getting deprecated altogether. This repository is not ready to be switched to Apple Silicon runners because CI is failing.